### PR TITLE
Fixed Namespace expired artifact gets converted to MosaicId instead of NamescapeId

### DIFF
--- a/sdk-okhttp-client/src/main/java/io/nem/symbol/sdk/infrastructure/okhttp/ReceiptMappingOkHttp.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/symbol/sdk/infrastructure/okhttp/ReceiptMappingOkHttp.java
@@ -22,6 +22,7 @@ import static io.nem.symbol.core.utils.MapperUtils.toMosaicId;
 import io.nem.symbol.core.utils.MapperUtils;
 import io.nem.symbol.sdk.model.account.PublicAccount;
 import io.nem.symbol.sdk.model.mosaic.MosaicId;
+import io.nem.symbol.sdk.model.namespace.NamespaceId;
 import io.nem.symbol.sdk.model.network.NetworkType;
 import io.nem.symbol.sdk.model.receipt.AddressResolutionStatement;
 import io.nem.symbol.sdk.model.receipt.ArtifactExpiryReceipt;
@@ -153,10 +154,10 @@ public class ReceiptMappingOkHttp {
         }
     }
 
-    public ArtifactExpiryReceipt<MosaicId> createArtifactExpiryReceipt(
+    public ArtifactExpiryReceipt<NamespaceId> createArtifactExpiryReceipt(
         NamespaceExpiryReceiptDTO receipt, ReceiptType type) {
         return new ArtifactExpiryReceipt<>(
-            MapperUtils.toMosaicId(receipt.getArtifactId()), type,
+            MapperUtils.toNamespaceId(receipt.getArtifactId()), type,
             ReceiptVersion.ARTIFACT_EXPIRY);
     }
 

--- a/sdk-okhttp-client/src/test/java/io/nem/symbol/sdk/infrastructure/okhttp/ReceiptMappingOkHttpTest.java
+++ b/sdk-okhttp-client/src/test/java/io/nem/symbol/sdk/infrastructure/okhttp/ReceiptMappingOkHttpTest.java
@@ -18,8 +18,13 @@ package io.nem.symbol.sdk.infrastructure.okhttp;
 
 import static io.nem.symbol.sdk.infrastructure.okhttp.TestHelperOkHttp.loadResource;
 
-import io.nem.symbol.sdk.model.receipt.ReceiptType;
+import io.nem.symbol.sdk.model.mosaic.MosaicId;
+import io.nem.symbol.sdk.model.namespace.NamespaceId;
 import io.nem.symbol.sdk.model.network.NetworkType;
+import io.nem.symbol.sdk.model.receipt.ArtifactExpiryReceipt;
+import io.nem.symbol.sdk.model.receipt.BalanceTransferReceipt;
+import io.nem.symbol.sdk.model.receipt.InflationReceipt;
+import io.nem.symbol.sdk.model.receipt.ReceiptType;
 import io.nem.symbol.sdk.model.receipt.Statement;
 import io.nem.symbol.sdk.model.receipt.TransactionStatement;
 import io.nem.symbol.sdk.model.transaction.JsonHelper;
@@ -60,14 +65,33 @@ public class ReceiptMappingOkHttpTest {
         Assertions.assertEquals(5, transactionStatement.getReceipts().size());
         Assertions.assertEquals(
             ReceiptType.NAMESPACE_RENTAL_FEE, transactionStatement.getReceipts().get(0).getType());
+
+        Assertions.assertEquals("85BBEA6CC462B244",
+            ((BalanceTransferReceipt) transactionStatement.getReceipts().get(0)).getMosaicId()
+                .getIdAsHex());
+
         Assertions.assertEquals(ReceiptType.MOSAIC_EXPIRED,
             transactionStatement.getReceipts().get(1).getType());
+        Assertions.assertEquals(MosaicId.class,
+            ((ArtifactExpiryReceipt) transactionStatement.getReceipts().get(1)).getArtifactId()
+                .getClass());
+
         Assertions.assertEquals(ReceiptType.NAMESPACE_EXPIRED,
             transactionStatement.getReceipts().get(2).getType());
+        Assertions.assertEquals(NamespaceId.class,
+            ((ArtifactExpiryReceipt) transactionStatement.getReceipts().get(2)).getArtifactId()
+                .getClass());
+
         Assertions.assertEquals(ReceiptType.NAMESPACE_DELETED,
             transactionStatement.getReceipts().get(3).getType());
+        Assertions.assertEquals(NamespaceId.class,
+            ((ArtifactExpiryReceipt) transactionStatement.getReceipts().get(3)).getArtifactId()
+                .getClass());
+
         Assertions.assertEquals(ReceiptType.INFLATION,
             transactionStatement.getReceipts().get(4).getType());
+        Assertions.assertEquals(333,
+            ((InflationReceipt) transactionStatement.getReceipts().get(4)).getAmount().longValue());
     }
 
     @Test

--- a/sdk-vertx-client/src/main/java/io/nem/symbol/sdk/infrastructure/vertx/ReceiptMappingVertx.java
+++ b/sdk-vertx-client/src/main/java/io/nem/symbol/sdk/infrastructure/vertx/ReceiptMappingVertx.java
@@ -22,6 +22,7 @@ import static io.nem.symbol.core.utils.MapperUtils.toMosaicId;
 import io.nem.symbol.core.utils.MapperUtils;
 import io.nem.symbol.sdk.model.account.PublicAccount;
 import io.nem.symbol.sdk.model.mosaic.MosaicId;
+import io.nem.symbol.sdk.model.namespace.NamespaceId;
 import io.nem.symbol.sdk.model.network.NetworkType;
 import io.nem.symbol.sdk.model.receipt.AddressResolutionStatement;
 import io.nem.symbol.sdk.model.receipt.ArtifactExpiryReceipt;
@@ -153,10 +154,10 @@ public class ReceiptMappingVertx {
         }
     }
 
-    public ArtifactExpiryReceipt<MosaicId> createArtifactExpiryReceipt(
+    public ArtifactExpiryReceipt<NamespaceId> createArtifactExpiryReceipt(
         NamespaceExpiryReceiptDTO receipt, ReceiptType type) {
         return new ArtifactExpiryReceipt<>(
-            MapperUtils.toMosaicId(receipt.getArtifactId()), type,
+            MapperUtils.toNamespaceId(receipt.getArtifactId()), type,
             ReceiptVersion.ARTIFACT_EXPIRY);
     }
 

--- a/sdk-vertx-client/src/test/java/io/nem/symbol/sdk/infrastructure/vertx/ReceiptMappingVertxTest.java
+++ b/sdk-vertx-client/src/test/java/io/nem/symbol/sdk/infrastructure/vertx/ReceiptMappingVertxTest.java
@@ -16,8 +16,13 @@
 
 package io.nem.symbol.sdk.infrastructure.vertx;
 
-import io.nem.symbol.sdk.model.receipt.ReceiptType;
+import io.nem.symbol.sdk.model.mosaic.MosaicId;
+import io.nem.symbol.sdk.model.namespace.NamespaceId;
 import io.nem.symbol.sdk.model.network.NetworkType;
+import io.nem.symbol.sdk.model.receipt.ArtifactExpiryReceipt;
+import io.nem.symbol.sdk.model.receipt.BalanceTransferReceipt;
+import io.nem.symbol.sdk.model.receipt.InflationReceipt;
+import io.nem.symbol.sdk.model.receipt.ReceiptType;
 import io.nem.symbol.sdk.model.receipt.Statement;
 import io.nem.symbol.sdk.model.receipt.TransactionStatement;
 import io.nem.symbol.sdk.model.transaction.JsonHelper;
@@ -58,14 +63,33 @@ public class ReceiptMappingVertxTest {
         Assertions.assertEquals(5, transactionStatement.getReceipts().size());
         Assertions.assertEquals(
             ReceiptType.NAMESPACE_RENTAL_FEE, transactionStatement.getReceipts().get(0).getType());
+
+        Assertions.assertEquals("85BBEA6CC462B244",
+            ((BalanceTransferReceipt) transactionStatement.getReceipts().get(0)).getMosaicId()
+                .getIdAsHex());
+
         Assertions.assertEquals(ReceiptType.MOSAIC_EXPIRED,
             transactionStatement.getReceipts().get(1).getType());
+        Assertions.assertEquals(MosaicId.class,
+            ((ArtifactExpiryReceipt) transactionStatement.getReceipts().get(1)).getArtifactId()
+                .getClass());
+
         Assertions.assertEquals(ReceiptType.NAMESPACE_EXPIRED,
             transactionStatement.getReceipts().get(2).getType());
+        Assertions.assertEquals(NamespaceId.class,
+            ((ArtifactExpiryReceipt) transactionStatement.getReceipts().get(2)).getArtifactId()
+                .getClass());
+
         Assertions.assertEquals(ReceiptType.NAMESPACE_DELETED,
             transactionStatement.getReceipts().get(3).getType());
+        Assertions.assertEquals(NamespaceId.class,
+            ((ArtifactExpiryReceipt) transactionStatement.getReceipts().get(3)).getArtifactId()
+                .getClass());
+
         Assertions.assertEquals(ReceiptType.INFLATION,
             transactionStatement.getReceipts().get(4).getType());
+        Assertions.assertEquals(333,
+            ((InflationReceipt) transactionStatement.getReceipts().get(4)).getAmount().longValue());
     }
 
     @Test


### PR DESCRIPTION
Fixed https://github.com/nemtech/symbol-sdk-java/issues/254