### PR TITLE
Alias resolution in listener

### DIFF
--- a/integration-tests/src/test/java/io/nem/symbol/sdk/infrastructure/AccountKeyLinkTransactionIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/symbol/sdk/infrastructure/AccountKeyLinkTransactionIntegrationTest.java
@@ -1,0 +1,39 @@
+package io.nem.symbol.sdk.infrastructure;
+
+import io.nem.symbol.core.crypto.PublicKey;
+import io.nem.symbol.sdk.model.account.Account;
+import io.nem.symbol.sdk.model.transaction.AccountKeyLinkTransaction;
+import io.nem.symbol.sdk.model.transaction.AccountKeyLinkTransactionFactory;
+import io.nem.symbol.sdk.model.transaction.LinkAction;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AccountKeyLinkTransactionIntegrationTest extends BaseIntegrationTest {
+
+    @ParameterizedTest
+    @EnumSource(RepositoryType.class)
+    public void basicAnnounce(RepositoryType type) {
+
+        Account account = config().getNemesisAccount2();
+        PublicKey linkedPublicKey = PublicKey
+            .fromHexString("F5D0AAD909CFBC810A3F888C33C57A9051AE1A59D1CDA872A8B90BCA7EF2D34A");
+
+        AccountKeyLinkTransaction linkTransaction =
+            AccountKeyLinkTransactionFactory.create(
+                getNetworkType(),
+                linkedPublicKey, LinkAction.LINK
+            ).maxFee(this.maxFee).build();
+
+        announceAndValidate(type, account, linkTransaction);
+
+        AccountKeyLinkTransaction unlinkTransaction =
+            AccountKeyLinkTransactionFactory.create(
+                getNetworkType(),
+                linkedPublicKey, LinkAction.UNLINK
+            ).maxFee(this.maxFee).build();
+
+        announceAndValidate(type, account, unlinkTransaction);
+    }
+}

--- a/integration-tests/src/test/java/io/nem/symbol/sdk/infrastructure/NodeKeyLinkTransactionIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/symbol/sdk/infrastructure/NodeKeyLinkTransactionIntegrationTest.java
@@ -1,0 +1,41 @@
+package io.nem.symbol.sdk.infrastructure;
+
+import io.nem.symbol.core.crypto.PublicKey;
+import io.nem.symbol.sdk.model.account.Account;
+import io.nem.symbol.sdk.model.transaction.LinkAction;
+import io.nem.symbol.sdk.model.transaction.NodeKeyLinkTransaction;
+import io.nem.symbol.sdk.model.transaction.NodeKeyLinkTransactionFactory;
+import io.nem.symbol.sdk.model.transaction.VrfKeyLinkTransaction;
+import io.nem.symbol.sdk.model.transaction.VrfKeyLinkTransactionFactory;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class NodeKeyLinkTransactionIntegrationTest extends BaseIntegrationTest {
+
+    @ParameterizedTest
+    @EnumSource(RepositoryType.class)
+    public void basicAnnounce(RepositoryType type) {
+
+        Account account = config().getNemesisAccount2();
+        PublicKey linkedPublicKey = PublicKey
+            .fromHexString("F5D0AAD909CFBC810A3F888C33C57A9051AE1A59D1CDA872A8B90BCA7EF2D34A");
+
+        NodeKeyLinkTransaction linkTransaction =
+            NodeKeyLinkTransactionFactory.create(
+                getNetworkType(),
+                linkedPublicKey, LinkAction.LINK
+            ).maxFee(this.maxFee).build();
+
+        announceAndValidate(type, account, linkTransaction);
+
+        NodeKeyLinkTransaction unlinkTransaction =
+            NodeKeyLinkTransactionFactory.create(
+                getNetworkType(),
+                linkedPublicKey, LinkAction.UNLINK
+            ).maxFee(this.maxFee).build();
+
+        announceAndValidate(type, account, unlinkTransaction);
+    }
+}

--- a/integration-tests/src/test/java/io/nem/symbol/sdk/infrastructure/TransferTransactionIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/symbol/sdk/infrastructure/TransferTransactionIntegrationTest.java
@@ -85,7 +85,6 @@ public class TransferTransactionIntegrationTest extends BaseIntegrationTest {
             recipient.encoded(getNetworkType()));
         String message = "E2ETest:standaloneTransferTransaction:message 漢字";
 
-        NetworkType networkType = getNetworkType();
         KeyPair senderKeyPair = KeyPair.random();
         KeyPair recipientKeyPair = KeyPair.random();
 

--- a/integration-tests/src/test/java/io/nem/symbol/sdk/infrastructure/VotingKeyLinkTransactionIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/symbol/sdk/infrastructure/VotingKeyLinkTransactionIntegrationTest.java
@@ -1,0 +1,38 @@
+package io.nem.symbol.sdk.infrastructure;
+
+import io.nem.symbol.core.crypto.VotingKey;
+import io.nem.symbol.sdk.model.account.Account;
+import io.nem.symbol.sdk.model.transaction.LinkAction;
+import io.nem.symbol.sdk.model.transaction.VotingKeyLinkTransaction;
+import io.nem.symbol.sdk.model.transaction.VotingKeyLinkTransactionFactory;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class VotingKeyLinkTransactionIntegrationTest extends BaseIntegrationTest {
+
+    @ParameterizedTest
+    @EnumSource(RepositoryType.class)
+    public void basicAnnounce(RepositoryType type) {
+
+        Account account = config().getNemesisAccount2();
+        VotingKey linkedPublicKey = VotingKey.fromHexString("AAAAA");
+
+        VotingKeyLinkTransaction linkTransaction =
+            VotingKeyLinkTransactionFactory.create(
+                getNetworkType(),
+                linkedPublicKey, LinkAction.LINK
+            ).maxFee(this.maxFee).build();
+
+        announceAndValidate(type, account, linkTransaction);
+
+        VotingKeyLinkTransaction unlinkTransaction =
+            VotingKeyLinkTransactionFactory.create(
+                getNetworkType(),
+                linkedPublicKey, LinkAction.UNLINK
+            ).maxFee(this.maxFee).build();
+
+        announceAndValidate(type, account, unlinkTransaction);
+    }
+}

--- a/integration-tests/src/test/java/io/nem/symbol/sdk/infrastructure/VrfKeyLinkTransactionIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/symbol/sdk/infrastructure/VrfKeyLinkTransactionIntegrationTest.java
@@ -1,0 +1,39 @@
+package io.nem.symbol.sdk.infrastructure;
+
+import io.nem.symbol.core.crypto.PublicKey;
+import io.nem.symbol.sdk.model.account.Account;
+import io.nem.symbol.sdk.model.transaction.LinkAction;
+import io.nem.symbol.sdk.model.transaction.VrfKeyLinkTransaction;
+import io.nem.symbol.sdk.model.transaction.VrfKeyLinkTransactionFactory;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class VrfKeyLinkTransactionIntegrationTest extends BaseIntegrationTest {
+
+    @ParameterizedTest
+    @EnumSource(RepositoryType.class)
+    public void basicAnnounce(RepositoryType type) {
+
+        Account account = config().getNemesisAccount2();
+        PublicKey linkedPublicKey = PublicKey
+            .fromHexString("F5D0AAD909CFBC810A3F888C33C57A9051AE1A59D1CDA872A8B90BCA7EF2D34A");
+
+        VrfKeyLinkTransaction linkTransaction =
+            VrfKeyLinkTransactionFactory.create(
+                getNetworkType(),
+                linkedPublicKey, LinkAction.LINK
+            ).maxFee(this.maxFee).build();
+
+        announceAndValidate(type, account, linkTransaction);
+
+        VrfKeyLinkTransaction unlinkTransaction =
+            VrfKeyLinkTransactionFactory.create(
+                getNetworkType(),
+                linkedPublicKey, LinkAction.UNLINK
+            ).maxFee(this.maxFee).build();
+
+        announceAndValidate(type, account, unlinkTransaction);
+    }
+}

--- a/sdk-core/src/main/java/io/nem/symbol/sdk/api/Listener.java
+++ b/sdk-core/src/main/java/io/nem/symbol/sdk/api/Listener.java
@@ -66,7 +66,18 @@ public interface Listener extends Closeable {
      * @param address address we listen when a transaction is in confirmed state
      * @return an observable stream of Transaction with state confirmed
      */
-    Observable<Transaction> confirmed(Address address);
+    default Observable<Transaction> confirmed(Address address) {
+        return this.confirmed(address, null);
+    }
+
+    /**
+     * Returns an observable stream of the transaction for the given address and transactionHash.
+     *
+     * @param address address we listen when a transaction is in confirmed state
+     * @param transactionHash the expected transaction hash
+     * @return an observable stream of Transaction with given transaction hash and state confirmed.
+     */
+    Observable<Transaction> confirmed(Address address, String transactionHash);
 
     /**
      * Returns an observable stream of the transaction of the given transactionHash. This stream is
@@ -80,7 +91,7 @@ public interface Listener extends Closeable {
      * @param transactionHash the expected transaction hash
      * @return an observable stream of Transaction with given transaction hash and state confirmed.
      */
-    Observable<Transaction> confirmed(Address address, String transactionHash);
+    Observable<Transaction> confirmedOrError(Address address, String transactionHash);
 
     /**
      * Returns an observable stream of Transaction for a specific address. Each time a transaction
@@ -90,7 +101,21 @@ public interface Listener extends Closeable {
      * @param address address we listen when a transaction is in unconfirmed state
      * @return an observable stream of Transaction with state unconfirmed
      */
-    Observable<Transaction> unconfirmedAdded(Address address);
+    default Observable<Transaction> unconfirmedAdded(Address address) {
+        return this.unconfirmedAdded(address, null);
+    }
+
+
+    /**
+     * Returns an observable stream of Transaction for a specific address. Each time a transaction
+     * is in unconfirmed state an it involves the address, it emits a new Transaction in the event
+     * stream.
+     *
+     * @param address address we listen when a transaction is in unconfirmed state
+     * @param transactionHash the expected transaction hash
+     * @return an observable stream of Transaction with state unconfirmed
+     */
+    Observable<Transaction> unconfirmedAdded(Address address, String transactionHash);
 
     /**
      * Returns an observable stream of Transaction Hashes for specific address. Each time a
@@ -100,7 +125,20 @@ public interface Listener extends Closeable {
      * @param address address we listen when a transaction is removed from unconfirmed state
      * @return an observable stream of Strings with the transaction hash
      */
-    Observable<String> unconfirmedRemoved(Address address);
+    default Observable<String> unconfirmedRemoved(Address address) {
+        return this.unconfirmedRemoved(address, null);
+    }
+
+    /**
+     * Returns an observable stream of Transaction Hashes for specific address. Each time a
+     * transaction with state unconfirmed changes its state, it emits a new message with the
+     * transaction hash in the event stream.
+     *
+     * @param address address we listen when a transaction is removed from unconfirmed state
+     * @param transactionHash the expected transaction hash
+     * @return an observable stream of Strings with the transaction hash
+     */
+    Observable<String> unconfirmedRemoved(Address address, String transactionHash);
 
     /**
      * Return an observable of {@link AggregateTransaction} for specific address. Each time an
@@ -110,7 +148,9 @@ public interface Listener extends Closeable {
      * @param address address we listen when a transaction with missing signatures state
      * @return an observable stream of AggregateTransaction with missing signatures state
      */
-    Observable<AggregateTransaction> aggregateBondedAdded(Address address);
+    default Observable<AggregateTransaction> aggregateBondedAdded(Address address) {
+        return this.aggregateBondedAdded(address, null);
+    }
 
     /**
      * Return an observable of {@link AggregateTransaction} for an specific address and transcation
@@ -125,6 +165,18 @@ public interface Listener extends Closeable {
      * @param transactionHash the expected transaction hash
      * @return an observable stream of AggregateTransaction with missing signatures state
      */
+    Observable<AggregateTransaction> aggregateBondedAddedOrError(Address address, String transactionHash);
+
+
+    /**
+     * Return an observable of {@link AggregateTransaction} for specific address and hash. Each time an
+     * aggregate bonded transaction is announced, it emits a new {@link AggregateTransaction} in the
+     * event stream.
+     *
+     * @param address address we listen when a transaction with missing signatures state
+     * @param transactionHash the expected transaction hash
+     * @return an observable stream of AggregateTransaction with missing signatures state
+     */
     Observable<AggregateTransaction> aggregateBondedAdded(Address address, String transactionHash);
 
     /**
@@ -135,7 +187,20 @@ public interface Listener extends Closeable {
      * @param address address we listen when a transaction is confirmed or rejected
      * @return an observable stream of Strings with the transaction hash
      */
-    Observable<String> aggregateBondedRemoved(Address address);
+    default Observable<String> aggregateBondedRemoved(Address address) {
+        return this.aggregateBondedRemoved(address, null);
+    }
+
+    /**
+     * Returns an observable stream of of the hash for specific address. Each time an
+     * aggregate bonded transaction is announced, it emits a new message with the transaction hash
+     * in the event stream.
+     *
+     * @param address address we listen when a transaction is confirmed or rejected
+     * @param transactionHash the expected transaction hash (optional)
+     * @return an observable stream of Strings with the transaction hash
+     */
+    Observable<String> aggregateBondedRemoved(Address address, String transactionHash);
 
     /**
      * Returns an observable stream of {@link TransactionStatusError} for specific address. Each
@@ -145,7 +210,19 @@ public interface Listener extends Closeable {
      * @param address address we listen to be notified when some error happened
      * @return an observable stream of {@link TransactionStatusError}
      */
-    Observable<TransactionStatusError> status(Address address);
+    default Observable<TransactionStatusError> status(Address address) {
+        return this.status(address, null);
+    }
+    /**
+     * Returns an observable stream of {@link TransactionStatusError} for specific address and hash. Each
+     * time a transaction contains an error, it emits a new message with the transaction status
+     * error in the event stream.
+     *
+     * @param address address we listen to be notified when some error happened
+     * @param transactionHash filter by transaction hash (optional)
+     * @return an observable stream of {@link TransactionStatusError}
+     */
+    Observable<TransactionStatusError> status(Address address, String transactionHash);
 
     /**
      * Returns an observable stream of {@link CosignatureSignedTransaction} for specific address.
@@ -156,5 +233,18 @@ public interface Listener extends Closeable {
      * sent
      * @return an observable stream of {@link CosignatureSignedTransaction}
      */
-    Observable<CosignatureSignedTransaction> cosignatureAdded(Address address);
+    default Observable<CosignatureSignedTransaction> cosignatureAdded(Address address){
+        return this.cosignatureAdded(address,null);
+    };
+    /**
+     * Returns an observable stream of {@link CosignatureSignedTransaction} for specific address.
+     * Each time a cosigner signs a transaction the address initialized, it emits a new message with
+     * the cosignatory signed transaction in the even stream.
+     *
+     * @param address address we listen when a cosignatory is added to some transaction address
+     * sent
+     * @param parentTransactionHash filter by parent transaction hash (optional)
+     * @return an observable stream of {@link CosignatureSignedTransaction}
+     */
+    Observable<CosignatureSignedTransaction> cosignatureAdded(Address address, String parentTransactionHash);
 }

--- a/sdk-core/src/main/java/io/nem/symbol/sdk/infrastructure/ListenerBase.java
+++ b/sdk-core/src/main/java/io/nem/symbol/sdk/infrastructure/ListenerBase.java
@@ -18,6 +18,7 @@ package io.nem.symbol.sdk.infrastructure;
 
 import io.nem.symbol.core.utils.MapperUtils;
 import io.nem.symbol.sdk.api.Listener;
+import io.nem.symbol.sdk.api.NamespaceRepository;
 import io.nem.symbol.sdk.model.account.Address;
 import io.nem.symbol.sdk.model.blockchain.BlockInfo;
 import io.nem.symbol.sdk.model.transaction.AggregateTransaction;
@@ -45,13 +46,15 @@ public abstract class ListenerBase implements Listener {
 
     private final Subject<ListenerMessage> messageSubject = PublishSubject.create();
 
-
     private final JsonHelper jsonHelper;
+    private final NamespaceRepository namespaceRepository;
 
     private String uid;
 
-    protected ListenerBase(JsonHelper jsonHelper) {
+    protected ListenerBase(JsonHelper jsonHelper,
+        NamespaceRepository namespaceRepository) {
         this.jsonHelper = jsonHelper;
+        this.namespaceRepository = namespaceRepository;
     }
 
     /**
@@ -102,140 +105,67 @@ public abstract class ListenerBase implements Listener {
             .map(rawMessage -> (BlockInfo) rawMessage.getMessage());
     }
 
-    /**
-     * Returns an observable stream of Transaction for a specific address. Each time a transaction
-     * is in confirmed state an it involves the address, it emits a new Transaction in the event
-     * stream.
-     *
-     * @param address address we listen when a transaction is in confirmed state
-     * @return an observable stream of Transaction with state confirmed
-     */
     @Override
-    public Observable<Transaction> confirmed(final Address address) {
-        Validate.notNull(address, "Address is required");
-        validateOpen();
-        this.subscribeTo(ListenerChannel.CONFIRMED_ADDED.toString() + "/" + address.plain());
-        return getMessageSubject()
-            .filter(rawMessage -> rawMessage.getChannel().equals(ListenerChannel.CONFIRMED_ADDED))
-            .map(rawMessage -> (Transaction) rawMessage.getMessage())
-            .filter(transaction -> this.transactionFromAddress(transaction, address));
+    public Observable<Transaction> confirmed(final Address address, final String transactionHash) {
+        return subscribeTransaction(ListenerChannel.CONFIRMED_ADDED, address, transactionHash);
     }
 
-
-    /**
-     * Returns an observable stream of Transaction for a specific address. Each time a transaction
-     * is in unconfirmed state an it involves the address, it emits a new Transaction in the event
-     * stream.
-     *
-     * @param address address we listen when a transaction is in unconfirmed state
-     * @return an observable stream of Transaction with state unconfirmed
-     */
     @Override
-    public Observable<Transaction> unconfirmedAdded(Address address) {
-        Validate.notNull(address, "Address is required");
-        validateOpen();
-        this.subscribeTo(ListenerChannel.UNCONFIRMED_ADDED + "/" + address.plain());
-        return getMessageSubject()
-            .filter(rawMessage -> rawMessage.getChannel().equals(ListenerChannel.UNCONFIRMED_ADDED))
-            .map(rawMessage -> (Transaction) rawMessage.getMessage())
-            .filter(transaction -> this.transactionFromAddress(transaction, address));
+    public Observable<Transaction> confirmedOrError(Address address, String transactionHash) {
+        // I may move this method to the Listener
+        Validate.notNull(transactionHash, "TransactionHash is required");
+        return getTransactionOrRaiseError(address, transactionHash,
+            confirmed(address, transactionHash));
     }
 
-    /**
-     * Returns an observable stream of Transaction Hashes for specific address. Each time a
-     * transaction with state unconfirmed changes its state, it emits a new message with the
-     * transaction hash in the event stream.
-     *
-     * @param address address we listen when a transaction is removed from unconfirmed state
-     * @return an observable stream of Strings with the transaction hash
-     */
     @Override
-    public Observable<String> unconfirmedRemoved(Address address) {
-        Validate.notNull(address, "Address is required");
-        validateOpen();
-        this.subscribeTo(ListenerChannel.UNCONFIRMED_REMOVED + "/" + address.plain());
-        return getMessageSubject()
-            .filter(
-                rawMessage -> rawMessage.getChannel().equals(ListenerChannel.UNCONFIRMED_REMOVED))
-            .map(rawMessage -> (String) rawMessage.getMessage());
+    public Observable<Transaction> unconfirmedAdded(Address address, String transactionHash) {
+        return subscribeTransaction(ListenerChannel.UNCONFIRMED_ADDED, address, transactionHash);
     }
 
-    /**
-     * Return an observable of {@link AggregateTransaction} for specific address. Each time an
-     * aggregate bonded transaction is announced, it emits a new {@link AggregateTransaction} in the
-     * event stream.
-     *
-     * @param address address we listen when a transaction with missing signatures state
-     * @return an observable stream of AggregateTransaction with missing signatures state
-     */
     @Override
-    public Observable<AggregateTransaction> aggregateBondedAdded(Address address) {
-        Validate.notNull(address, "Address is required");
-        validateOpen();
-        this.subscribeTo(ListenerChannel.AGGREGATE_BONDED_ADDED + "/" + address.plain());
-        return getMessageSubject()
-            .filter(rawMessage -> rawMessage.getChannel()
-                .equals(ListenerChannel.AGGREGATE_BONDED_ADDED))
-            .map(rawMessage -> (AggregateTransaction) rawMessage.getMessage())
-            .filter(transaction -> this.transactionFromAddress(transaction, address));
+    public Observable<String> unconfirmedRemoved(Address address, String transactionHash) {
+        return subscribeTransactionHash(ListenerChannel.UNCONFIRMED_REMOVED, address,
+            transactionHash);
     }
 
-    /**
-     * Returns an observable stream of Transaction Hashes for specific address. Each time an
-     * aggregate bonded transaction is announced, it emits a new message with the transaction hash
-     * in the event stream.
-     *
-     * @param address address we listen when a transaction is confirmed or rejected
-     * @return an observable stream of Strings with the transaction hash
-     */
     @Override
-    public Observable<String> aggregateBondedRemoved(Address address) {
-        Validate.notNull(address, "Address is required");
-        validateOpen();
-        this.subscribeTo(ListenerChannel.AGGREGATE_BONDED_REMOVED + "/" + address.plain());
-        return getMessageSubject()
-            .filter(
-                rawMessage -> rawMessage.getChannel()
-                    .equals(ListenerChannel.AGGREGATE_BONDED_REMOVED))
-            .map(rawMessage -> (String) rawMessage.getMessage());
+    public Observable<AggregateTransaction> aggregateBondedAdded(Address address,
+        String transactionHash) {
+        return subscribeTransaction(ListenerChannel.AGGREGATE_BONDED_ADDED, address,
+            transactionHash);
     }
 
-    /**
-     * Returns an observable stream of {@link TransactionStatusError} for specific address. Each
-     * time a transaction contains an error, it emits a new message with the transaction status
-     * error in the event stream.
-     *
-     * @param address address we listen to be notified when some error happened
-     * @return an observable stream of {@link TransactionStatusError}
-     */
     @Override
-    public Observable<TransactionStatusError> status(Address address) {
+    public Observable<String> aggregateBondedRemoved(Address address, String transactionHash) {
+        return subscribeTransactionHash(ListenerChannel.AGGREGATE_BONDED_REMOVED, address,
+            transactionHash);
+    }
+
+    @Override
+    public Observable<TransactionStatusError> status(Address address, String transactionHash) {
         Validate.notNull(address, "Address is required");
         validateOpen();
         this.subscribeTo(ListenerChannel.STATUS + "/" + address.plain());
         return getMessageSubject()
             .filter(rawMessage -> rawMessage.getChannel().equals(ListenerChannel.STATUS))
             .map(rawMessage -> (TransactionStatusError) rawMessage.getMessage())
-            .filter(status -> address.equals(status.getAddress()));
+            .filter(status -> address.equals(status.getAddress()))
+            .filter(status -> transactionHash == null || transactionHash
+                .equalsIgnoreCase(status.getHash()));
     }
 
-    /**
-     * Returns an observable stream of {@link CosignatureSignedTransaction} for specific address.
-     * Each time a cosigner signs a transaction the address initialized, it emits a new message with
-     * the cosignatory signed transaction in the even stream.
-     *
-     * @param address address we listen when a cosignatory is added to some transaction address
-     * sent
-     * @return an observable stream of {@link CosignatureSignedTransaction}
-     */
     @Override
-    public Observable<CosignatureSignedTransaction> cosignatureAdded(Address address) {
+    public Observable<CosignatureSignedTransaction> cosignatureAdded(Address address,
+        String parentTransactionHash) {
         Validate.notNull(address, "Address is required");
         validateOpen();
         this.subscribeTo(ListenerChannel.COSIGNATURE + "/" + address.plain());
         return getMessageSubject()
             .filter(rawMessage -> rawMessage.getChannel().equals(ListenerChannel.COSIGNATURE))
-            .map(rawMessage -> (CosignatureSignedTransaction) rawMessage.getMessage());
+            .map(rawMessage -> (CosignatureSignedTransaction) rawMessage.getMessage())
+            .filter(status -> parentTransactionHash == null || parentTransactionHash
+                .equalsIgnoreCase(status.getParentHash()));
     }
 
     private void validateOpen() {
@@ -246,41 +176,15 @@ public abstract class ListenerBase implements Listener {
     }
 
     @Override
-    public Observable<Transaction> confirmed(Address address, String transactionHash) {
-
-        // I may move this method to the Listener
-        Validate.notNull(address, "Address is required");
-        Validate.notNull(transactionHash, "TransactionHash is required");
-
-        Observable<Transaction> transactionListener = confirmed(address)
-            .filter(t -> t.getTransactionInfo()
-                .filter(
-                    info -> info.getHash().filter(transactionHash::equalsIgnoreCase).isPresent())
-                .isPresent());
-
-        return getTransactionOrRaiseError(address, transactionHash, transactionListener);
-    }
-
-    @Override
-    public Observable<AggregateTransaction> aggregateBondedAdded(Address address,
+    public Observable<AggregateTransaction> aggregateBondedAddedOrError(Address address,
         String transactionHash) {
-        Validate.notNull(address, "Address is required");
-        Validate.notNull(transactionHash, "TransactionHash is required");
-
-        // I may move this method to the Listener
-        Observable<AggregateTransaction> transactionListener = aggregateBondedAdded(address)
-            .filter(t -> t.getTransactionInfo()
-                .filter(
-                    info -> info.getHash().filter(transactionHash::equalsIgnoreCase).isPresent())
-                .isPresent());
-
-        return getTransactionOrRaiseError(address, transactionHash, transactionListener);
+        return getTransactionOrRaiseError(address, transactionHash,
+            aggregateBondedAdded(address, transactionHash));
     }
 
 
     private <T extends Transaction> Observable<T> getTransactionOrRaiseError(Address address,
         String transactionHash, Observable<T> transactionListener) {
-
         // I may move this method to the Listener
         IllegalStateException caller = new IllegalStateException("The Caller");
         Observable<TransactionStatusError> errorListener = status(address)
@@ -297,6 +201,34 @@ public abstract class ListenerBase implements Listener {
         });
     }
 
+
+    private <T extends Transaction> Observable<T> subscribeTransaction(ListenerChannel channel,
+        Address address,
+        String transactionHash) {
+        Validate.notNull(address, "Address is required");
+        validateOpen();
+        this.subscribeTo(channel.toString() + "/" + address.plain());
+        return getMessageSubject()
+            .filter(rawMessage -> rawMessage.getChannel().equals(channel))
+            .map(rawMessage -> (T) rawMessage.getMessage())
+            .filter(t -> t.getTransactionInfo()
+                .filter(
+                    info -> transactionHash == null || info.getHash()
+                        .filter(transactionHash::equalsIgnoreCase).isPresent())
+                .isPresent())
+            .filter(transaction -> this.transactionFromAddress(transaction, address));
+    }
+
+    private Observable<String> subscribeTransactionHash(ListenerChannel channel, Address address,
+        String transactionHash) {
+        Validate.notNull(address, "Address is required");
+        validateOpen();
+        this.subscribeTo(channel + "/" + address.plain());
+        return getMessageSubject()
+            .filter(rawMessage -> rawMessage.getChannel().equals(channel))
+            .map(rawMessage -> (String) rawMessage.getMessage())
+            .filter(hash -> transactionHash == null || transactionHash.equalsIgnoreCase(hash));
+    }
 
     public boolean transactionFromAddress(final Transaction transaction, final Address address) {
         if (transaction.getSigner().filter(s -> s.getAddress().equals(address)).isPresent()) {

--- a/sdk-core/src/main/java/io/nem/symbol/sdk/infrastructure/TransactionServiceImpl.java
+++ b/sdk-core/src/main/java/io/nem/symbol/sdk/infrastructure/TransactionServiceImpl.java
@@ -95,7 +95,7 @@ public class TransactionServiceImpl implements TransactionService {
         Observable<TransactionAnnounceResponse> announce = transactionRepository
             .announce(signedTransaction);
         return announce.flatMap(
-            r -> listener.confirmed(signedTransaction.getSigner().getAddress(),
+            r -> listener.confirmedOrError(signedTransaction.getSigner().getAddress(),
                 signedTransaction.getHash()));
     }
 
@@ -108,7 +108,7 @@ public class TransactionServiceImpl implements TransactionService {
         Observable<TransactionAnnounceResponse> announce = transactionRepository
             .announceAggregateBonded(signedAggregateTransaction);
         return announce.flatMap(
-            r -> listener.aggregateBondedAdded(signedAggregateTransaction.getSigner().getAddress(),
+            r -> listener.aggregateBondedAddedOrError(signedAggregateTransaction.getSigner().getAddress(),
                 signedAggregateTransaction.getHash()));
     }
 

--- a/sdk-core/src/main/java/io/nem/symbol/sdk/model/transaction/AccountKeyLinkTransactionFactory.java
+++ b/sdk-core/src/main/java/io/nem/symbol/sdk/model/transaction/AccountKeyLinkTransactionFactory.java
@@ -34,7 +34,7 @@ public class AccountKeyLinkTransactionFactory extends TransactionFactory<Account
         final PublicKey linkedPublicKey,
         final LinkAction linkAction) {
         super(TransactionType.ACCOUNT_KEY_LINK, networkType);
-        Validate.notNull(linkedPublicKey, "RemoteAccount must not be null");
+        Validate.notNull(linkedPublicKey, "LinkedPublicKey must not be null");
         Validate.notNull(linkAction, "LinkAction must not be null");
         this.linkedPublicKey = linkedPublicKey;
         this.linkAction = linkAction;

--- a/sdk-core/src/main/java/io/nem/symbol/sdk/model/transaction/MosaicAddressRestrictionTransaction.java
+++ b/sdk-core/src/main/java/io/nem/symbol/sdk/model/transaction/MosaicAddressRestrictionTransaction.java
@@ -34,7 +34,8 @@ import java.math.BigInteger;
  *
  * @since 1.0
  */
-public class MosaicAddressRestrictionTransaction extends Transaction {
+public class MosaicAddressRestrictionTransaction extends Transaction implements
+    TargetAddressTransaction{
 
     private final UnresolvedMosaicId mosaicId;
     private final BigInteger restrictionKey;
@@ -79,6 +80,7 @@ public class MosaicAddressRestrictionTransaction extends Transaction {
      *
      * @return {@link Address}
      */
+    @Override
     public UnresolvedAddress getTargetAddress() {
         return targetAddress;
     }

--- a/sdk-core/src/main/java/io/nem/symbol/sdk/model/transaction/MosaicAddressRestrictionTransactionFactory.java
+++ b/sdk-core/src/main/java/io/nem/symbol/sdk/model/transaction/MosaicAddressRestrictionTransactionFactory.java
@@ -26,7 +26,8 @@ import org.apache.commons.lang3.Validate;
  * Factory of {@link MosaicAddressRestrictionTransaction}
  */
 public class MosaicAddressRestrictionTransactionFactory
-    extends TransactionFactory<MosaicAddressRestrictionTransaction> {
+    extends TransactionFactory<MosaicAddressRestrictionTransaction> implements
+    TargetAddressTransaction {
 
     private final UnresolvedMosaicId mosaicId;
     private final BigInteger restrictionKey;
@@ -76,7 +77,8 @@ public class MosaicAddressRestrictionTransactionFactory
         BigInteger restrictionKey,
         UnresolvedAddress targetAddress,
         BigInteger newRestrictionValue) {
-        return new MosaicAddressRestrictionTransactionFactory(networkType, mosaicId, restrictionKey, targetAddress, newRestrictionValue);
+        return new MosaicAddressRestrictionTransactionFactory(networkType, mosaicId, restrictionKey,
+            targetAddress, newRestrictionValue);
     }
 
     @Override
@@ -107,6 +109,7 @@ public class MosaicAddressRestrictionTransactionFactory
      *
      * @return {@link UnresolvedAddress}
      */
+    @Override
     public UnresolvedAddress getTargetAddress() {
         return targetAddress;
     }
@@ -122,6 +125,7 @@ public class MosaicAddressRestrictionTransactionFactory
 
     /**
      * It sets the previoudRestrictionValue when necessary.
+     *
      * @param previousRestrictionValue the previous restriction value
      * @return this factory.
      */

--- a/sdk-core/src/main/java/io/nem/symbol/sdk/model/transaction/NodeKeyLinkTransaction.java
+++ b/sdk-core/src/main/java/io/nem/symbol/sdk/model/transaction/NodeKeyLinkTransaction.java
@@ -21,7 +21,7 @@ import io.nem.symbol.core.crypto.PublicKey;
 /**
  * Voting key link transaction.
  */
-public class NodeKeyLinkTransaction extends Transaction {
+public class NodeKeyLinkTransaction extends Transaction implements PublicKeyLinkTransaction {
 
     /**
      * The linked public key.

--- a/sdk-core/src/main/java/io/nem/symbol/sdk/model/transaction/PublicKeyLinkTransaction.java
+++ b/sdk-core/src/main/java/io/nem/symbol/sdk/model/transaction/PublicKeyLinkTransaction.java
@@ -19,36 +19,22 @@ package io.nem.symbol.sdk.model.transaction;
 import io.nem.symbol.core.crypto.PublicKey;
 
 /**
- *
+ * A Transaction operation related to a {@link PublicKey}.
  */
-public class AccountKeyLinkTransaction extends Transaction implements PublicKeyLinkTransaction {
-
-    private final PublicKey linkedPublicKey;
-
-    private final LinkAction linkAction;
-
-    public AccountKeyLinkTransaction(AccountKeyLinkTransactionFactory factory) {
-        super(factory);
-        this.linkedPublicKey = factory.getLinkedPublicKey();
-        this.linkAction = factory.getLinkAction();
-    }
+public interface PublicKeyLinkTransaction {
 
     /**
      * Gets the linked public key.
      *
      * @return Public key.
      */
-    public PublicKey getLinkedPublicKey() {
-        return linkedPublicKey;
-    }
+    PublicKey getLinkedPublicKey();
 
     /**
      * Gets the link action.
      *
      * @return Link action.
      */
-    public LinkAction getLinkAction() {
-        return linkAction;
-    }
+    LinkAction getLinkAction();
 
 }

--- a/sdk-core/src/main/java/io/nem/symbol/sdk/model/transaction/RecipientTransaction.java
+++ b/sdk-core/src/main/java/io/nem/symbol/sdk/model/transaction/RecipientTransaction.java
@@ -1,0 +1,16 @@
+package io.nem.symbol.sdk.model.transaction;
+
+import io.nem.symbol.sdk.model.account.UnresolvedAddress;
+
+/**
+ * A transaction linked to a recipient.
+ */
+public interface RecipientTransaction {
+
+    /**
+     * Returns address of the recipient.
+     *
+     * @return recipient address
+     */
+    UnresolvedAddress getRecipient();
+}

--- a/sdk-core/src/main/java/io/nem/symbol/sdk/model/transaction/SecretLockTransaction.java
+++ b/sdk-core/src/main/java/io/nem/symbol/sdk/model/transaction/SecretLockTransaction.java
@@ -20,7 +20,7 @@ import io.nem.symbol.sdk.model.account.UnresolvedAddress;
 import io.nem.symbol.sdk.model.mosaic.Mosaic;
 import java.math.BigInteger;
 
-public class SecretLockTransaction extends Transaction {
+public class SecretLockTransaction extends Transaction implements RecipientTransaction {
 
     private final Mosaic mosaic;
     private final BigInteger duration;
@@ -84,6 +84,7 @@ public class SecretLockTransaction extends Transaction {
      *
      * @return the recipient of the funds.
      */
+    @Override
     public UnresolvedAddress getRecipient() {
         return recipient;
     }

--- a/sdk-core/src/main/java/io/nem/symbol/sdk/model/transaction/SecretProofTransaction.java
+++ b/sdk-core/src/main/java/io/nem/symbol/sdk/model/transaction/SecretProofTransaction.java
@@ -21,7 +21,7 @@ import io.nem.symbol.sdk.model.account.UnresolvedAddress;
 /**
  * Secret proof transaction.
  */
-public class SecretProofTransaction extends Transaction {
+public class SecretProofTransaction extends Transaction implements RecipientTransaction {
 
     private final LockHashAlgorithmType hashType;
     private final String secret;
@@ -74,6 +74,7 @@ public class SecretProofTransaction extends Transaction {
     /**
      * @return the recipient
      */
+    @Override
     public UnresolvedAddress getRecipient() {
         return recipient;
     }

--- a/sdk-core/src/main/java/io/nem/symbol/sdk/model/transaction/TargetAddressTransaction.java
+++ b/sdk-core/src/main/java/io/nem/symbol/sdk/model/transaction/TargetAddressTransaction.java
@@ -1,0 +1,17 @@
+package io.nem.symbol.sdk.model.transaction;
+
+import io.nem.symbol.sdk.model.account.Address;
+import io.nem.symbol.sdk.model.account.UnresolvedAddress;
+
+/**
+ * Transactions with targeted to an address.
+ */
+public interface TargetAddressTransaction {
+
+    /**
+     * Returns the target address.
+     *
+     * @return {@link Address }
+     */
+    UnresolvedAddress getTargetAddress();
+}

--- a/sdk-core/src/main/java/io/nem/symbol/sdk/model/transaction/TransferTransaction.java
+++ b/sdk-core/src/main/java/io/nem/symbol/sdk/model/transaction/TransferTransaction.java
@@ -25,7 +25,7 @@ import java.util.List;
  * The transfer transactions object contain data about transfers of mosaics and message to another
  * account.
  */
-public class TransferTransaction extends Transaction {
+public class TransferTransaction extends Transaction implements RecipientTransaction {
 
     private final UnresolvedAddress recipient;
     private final List<Mosaic> mosaics;
@@ -48,6 +48,7 @@ public class TransferTransaction extends Transaction {
      *
      * @return recipient address
      */
+    @Override
     public UnresolvedAddress getRecipient() {
         return recipient;
     }

--- a/sdk-core/src/main/java/io/nem/symbol/sdk/model/transaction/VrfKeyLinkTransaction.java
+++ b/sdk-core/src/main/java/io/nem/symbol/sdk/model/transaction/VrfKeyLinkTransaction.java
@@ -21,7 +21,7 @@ import io.nem.symbol.core.crypto.PublicKey;
 /**
  * Vrf key link transaction.
  */
-public class VrfKeyLinkTransaction extends Transaction {
+public class VrfKeyLinkTransaction extends Transaction implements PublicKeyLinkTransaction {
 
     /**
      * The linked public key.

--- a/sdk-core/src/test/java/io/nem/symbol/sdk/infrastructure/TransactionServiceTest.java
+++ b/sdk-core/src/test/java/io/nem/symbol/sdk/infrastructure/TransactionServiceTest.java
@@ -150,7 +150,7 @@ class TransactionServiceTest {
             Observable.just(transactionAnnounceResponse));
 
         Mockito
-            .when(listener.confirmed(Mockito.eq(account.getAddress()),
+            .when(listener.confirmedOrError(Mockito.eq(account.getAddress()),
                 Mockito.eq(signedTransaction.getHash())))
             .thenReturn(Observable.just(transferTransaction));
 
@@ -180,7 +180,7 @@ class TransactionServiceTest {
             Observable.just(aggregateTransactionAnnounceResponse));
 
         Mockito
-            .when(listener.aggregateBondedAdded(Mockito.eq(account.getAddress()),
+            .when(listener.aggregateBondedAddedOrError(Mockito.eq(account.getAddress()),
                 Mockito.eq(aggregateSignedTransaction.getHash())))
             .thenReturn(Observable.just(aggregateTransaction));
 
@@ -228,12 +228,12 @@ class TransactionServiceTest {
                 Observable.just(hashTransactionAnnounceResponse));
 
         Mockito
-            .when(listener.confirmed(Mockito.eq(account.getAddress()),
+            .when(listener.confirmedOrError(Mockito.eq(account.getAddress()),
                 Mockito.eq(hashLockSignedTranscation.getHash())))
             .thenReturn(Observable.just(hashLockTransaction));
 
         Mockito
-            .when(listener.aggregateBondedAdded(Mockito.eq(account.getAddress()),
+            .when(listener.aggregateBondedAddedOrError(Mockito.eq(account.getAddress()),
                 Mockito.eq(aggregateSignedTransaction.getHash())))
             .thenReturn(Observable.just(aggregateTransaction));
 

--- a/sdk-okhttp-client/src/main/java/io/nem/symbol/sdk/infrastructure/okhttp/ListenerOkHttp.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/symbol/sdk/infrastructure/okhttp/ListenerOkHttp.java
@@ -18,6 +18,7 @@ package io.nem.symbol.sdk.infrastructure.okhttp;
 
 import com.google.gson.JsonObject;
 import io.nem.symbol.sdk.api.Listener;
+import io.nem.symbol.sdk.api.NamespaceRepository;
 import io.nem.symbol.sdk.infrastructure.ListenerBase;
 import io.nem.symbol.sdk.infrastructure.ListenerSubscribeMessage;
 import io.nem.symbol.sdk.infrastructure.okhttp.mappers.GeneralTransactionMapper;
@@ -58,8 +59,9 @@ public class ListenerOkHttp extends ListenerBase implements Listener {
      * @param url nis host
      * @param json gson's json.
      */
-    public ListenerOkHttp(OkHttpClient httpClient, String url, JSON json) {
-        super(new JsonHelperGson(json.getGson()));
+    public ListenerOkHttp(OkHttpClient httpClient, String url, JSON json,
+        NamespaceRepository namespaceRepository) {
+        super(new JsonHelperGson(json.getGson()), namespaceRepository);
         try {
             this.url = new URL(url);
         } catch (MalformedURLException e) {

--- a/sdk-okhttp-client/src/main/java/io/nem/symbol/sdk/infrastructure/okhttp/RepositoryFactoryOkHttpImpl.java
+++ b/sdk-okhttp-client/src/main/java/io/nem/symbol/sdk/infrastructure/okhttp/RepositoryFactoryOkHttpImpl.java
@@ -128,7 +128,7 @@ public class RepositoryFactoryOkHttpImpl extends RepositoryFactoryBase {
 
     @Override
     public Listener createListener() {
-        return new ListenerOkHttp(apiClient.getHttpClient(), getBaseUrl(), apiClient.getJSON());
+        return new ListenerOkHttp(apiClient.getHttpClient(), getBaseUrl(), apiClient.getJSON(), createNamespaceRepository());
     }
 
     @Override

--- a/sdk-okhttp-client/src/test/java/io/nem/symbol/sdk/infrastructure/okhttp/ListenerOkHttpTest.java
+++ b/sdk-okhttp-client/src/test/java/io/nem/symbol/sdk/infrastructure/okhttp/ListenerOkHttpTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.gson.JsonObject;
 import io.nem.symbol.sdk.api.Listener;
+import io.nem.symbol.sdk.api.NamespaceRepository;
 import io.nem.symbol.sdk.infrastructure.ListenerChannel;
 import io.nem.symbol.sdk.infrastructure.ListenerSubscribeMessage;
 import io.nem.symbol.sdk.model.account.Account;
@@ -61,6 +62,7 @@ public class ListenerOkHttpTest {
     private ListenerOkHttp listener;
 
     private OkHttpClient httpClientMock;
+    private NamespaceRepository namespaceRepository;
 
     private WebSocket webSocketMock;
 
@@ -71,8 +73,9 @@ public class ListenerOkHttpTest {
     @BeforeEach
     public void setUp() {
         httpClientMock = Mockito.mock(OkHttpClient.class);
+        namespaceRepository = Mockito.mock(NamespaceRepository.class);
         String url = "http://nem.com:3000/";
-        listener = new ListenerOkHttp(httpClientMock, url, new JSON());
+        listener = new ListenerOkHttp(httpClientMock, url, new JSON(), namespaceRepository);
         jsonHelper = listener.getJsonHelper();
     }
 

--- a/sdk-okhttp-client/src/test/java/io/nem/symbol/sdk/infrastructure/okhttp/ListenerOkHttpTest.java
+++ b/sdk-okhttp-client/src/test/java/io/nem/symbol/sdk/infrastructure/okhttp/ListenerOkHttpTest.java
@@ -62,6 +62,7 @@ public class ListenerOkHttpTest {
     private ListenerOkHttp listener;
 
     private OkHttpClient httpClientMock;
+
     private NamespaceRepository namespaceRepository;
 
     private WebSocket webSocketMock;
@@ -211,7 +212,7 @@ public class ListenerOkHttpTest {
 
         List<Transaction> transactions = new ArrayList<>();
         List<Throwable> exceptions = new ArrayList<>();
-        listener.confirmed(address, transactionInfo.getMeta().getHash()).doOnError(exceptions::add)
+        listener.confirmedOrError(address, transactionInfo.getMeta().getHash()).doOnError(exceptions::add)
             .forEach(transactions::add);
 
         listener.handle(transactionInfoDtoJsonObject, null);
@@ -255,7 +256,7 @@ public class ListenerOkHttpTest {
 
         List<Transaction> transactions = new ArrayList<>();
         List<Throwable> exceptions = new ArrayList<>();
-        listener.confirmed(address, transactionInfo.getMeta().getHash()).doOnError(exceptions::add)
+        listener.confirmedOrError(address, transactionInfo.getMeta().getHash()).doOnError(exceptions::add)
             .forEach(transactions::add);
 
         listener.handle(transactionStatusError, null);
@@ -298,7 +299,7 @@ public class ListenerOkHttpTest {
 
         List<Transaction> transactions = new ArrayList<>();
         List<Throwable> exceptions = new ArrayList<>();
-        listener.aggregateBondedAdded(address, transactionInfo.getMeta().getHash())
+        listener.aggregateBondedAddedOrError(address, transactionInfo.getMeta().getHash())
             .doOnError(exceptions::add)
             .forEach(transactions::add);
 
@@ -343,7 +344,7 @@ public class ListenerOkHttpTest {
 
         List<Transaction> transactions = new ArrayList<>();
         List<Throwable> exceptions = new ArrayList<>();
-        listener.aggregateBondedAdded(address, transactionInfo.getMeta().getHash())
+        listener.aggregateBondedAddedOrError(address, transactionInfo.getMeta().getHash())
             .doOnError(exceptions::add)
             .forEach(transactions::add);
 

--- a/sdk-vertx-client/src/main/java/io/nem/symbol/sdk/infrastructure/vertx/ListenerVertx.java
+++ b/sdk-vertx-client/src/main/java/io/nem/symbol/sdk/infrastructure/vertx/ListenerVertx.java
@@ -18,6 +18,7 @@ package io.nem.symbol.sdk.infrastructure.vertx;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.nem.symbol.sdk.api.Listener;
+import io.nem.symbol.sdk.api.NamespaceRepository;
 import io.nem.symbol.sdk.infrastructure.ListenerBase;
 import io.nem.symbol.sdk.infrastructure.ListenerSubscribeMessage;
 import io.nem.symbol.sdk.infrastructure.vertx.mappers.GeneralTransactionMapper;
@@ -57,8 +58,10 @@ public class ListenerVertx extends ListenerBase implements Listener {
      * @param httpClient the http client instance.
      * @param url of the host
      */
-    public ListenerVertx(HttpClient httpClient, String url) {
-        super(new JsonHelperJackson2(JsonHelperJackson2.configureMapper(Json.mapper)));
+    public ListenerVertx(HttpClient httpClient, String url,
+        NamespaceRepository namespaceRepository) {
+        super(new JsonHelperJackson2(JsonHelperJackson2.configureMapper(Json.mapper)),
+            namespaceRepository);
         try {
             this.url = new URL(url);
         } catch (MalformedURLException e) {

--- a/sdk-vertx-client/src/main/java/io/nem/symbol/sdk/infrastructure/vertx/RepositoryFactoryVertxImpl.java
+++ b/sdk-vertx-client/src/main/java/io/nem/symbol/sdk/infrastructure/vertx/RepositoryFactoryVertxImpl.java
@@ -141,7 +141,8 @@ public class RepositoryFactoryVertxImpl extends RepositoryFactoryBase {
 
     @Override
     public Listener createListener() {
-        return new ListenerVertx(vertx.createHttpClient(), getBaseUrl());
+        return new ListenerVertx(vertx.createHttpClient(), getBaseUrl(),
+            createNamespaceRepository());
     }
 
     @Override

--- a/sdk-vertx-client/src/test/java/io/nem/symbol/sdk/infrastructure/vertx/ListenerVertxTest.java
+++ b/sdk-vertx-client/src/test/java/io/nem/symbol/sdk/infrastructure/vertx/ListenerVertxTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.nem.symbol.core.utils.MapperUtils;
 import io.nem.symbol.sdk.api.Listener;
+import io.nem.symbol.sdk.api.NamespaceRepository;
 import io.nem.symbol.sdk.infrastructure.ListenerChannel;
 import io.nem.symbol.sdk.infrastructure.ListenerSubscribeMessage;
 import io.nem.symbol.sdk.model.account.Account;
@@ -87,11 +88,14 @@ public class ListenerVertxTest {
 
     private String wsId = "TheWSid";
 
+    private NamespaceRepository namespaceRepository;
+
     @BeforeEach
     public void setUp() {
         httpClientMock = Mockito.mock(HttpClient.class);
         String url = "http://nem.com:3000/";
-        listener = new ListenerVertx(httpClientMock, url);
+        namespaceRepository = Mockito.mock(NamespaceRepository.class);
+        listener = new ListenerVertx(httpClientMock, url, namespaceRepository);
         jsonHelper = listener.getJsonHelper();
         webSocketMock = Mockito.mock(WebSocket.class);
     }

--- a/sdk-vertx-client/src/test/java/io/nem/symbol/sdk/infrastructure/vertx/ListenerVertxTest.java
+++ b/sdk-vertx-client/src/test/java/io/nem/symbol/sdk/infrastructure/vertx/ListenerVertxTest.java
@@ -19,18 +19,30 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.nem.symbol.core.crypto.PublicKey;
+import io.nem.symbol.core.utils.ConvertUtils;
 import io.nem.symbol.core.utils.MapperUtils;
 import io.nem.symbol.sdk.api.Listener;
 import io.nem.symbol.sdk.api.NamespaceRepository;
 import io.nem.symbol.sdk.infrastructure.ListenerChannel;
 import io.nem.symbol.sdk.infrastructure.ListenerSubscribeMessage;
+import io.nem.symbol.sdk.infrastructure.SerializationUtils;
 import io.nem.symbol.sdk.model.account.Account;
+import io.nem.symbol.sdk.model.account.AccountNames;
 import io.nem.symbol.sdk.model.account.Address;
 import io.nem.symbol.sdk.model.account.PublicAccount;
+import io.nem.symbol.sdk.model.account.UnresolvedAddress;
 import io.nem.symbol.sdk.model.message.PlainMessage;
 import io.nem.symbol.sdk.model.mosaic.Mosaic;
 import io.nem.symbol.sdk.model.mosaic.MosaicId;
+import io.nem.symbol.sdk.model.namespace.NamespaceId;
+import io.nem.symbol.sdk.model.namespace.NamespaceName;
 import io.nem.symbol.sdk.model.network.NetworkType;
+import io.nem.symbol.sdk.model.transaction.AccountAddressRestrictionTransaction;
+import io.nem.symbol.sdk.model.transaction.AccountAddressRestrictionTransactionFactory;
+import io.nem.symbol.sdk.model.transaction.AccountMetadataTransaction;
+import io.nem.symbol.sdk.model.transaction.AccountMetadataTransactionFactory;
+import io.nem.symbol.sdk.model.transaction.AccountRestrictionFlags;
 import io.nem.symbol.sdk.model.transaction.AggregateTransaction;
 import io.nem.symbol.sdk.model.transaction.AggregateTransactionCosignature;
 import io.nem.symbol.sdk.model.transaction.AggregateTransactionFactory;
@@ -38,6 +50,7 @@ import io.nem.symbol.sdk.model.transaction.CosignatureSignedTransaction;
 import io.nem.symbol.sdk.model.transaction.HashLockTransaction;
 import io.nem.symbol.sdk.model.transaction.HashLockTransactionFactory;
 import io.nem.symbol.sdk.model.transaction.JsonHelper;
+import io.nem.symbol.sdk.model.transaction.LinkAction;
 import io.nem.symbol.sdk.model.transaction.MultisigAccountModificationTransaction;
 import io.nem.symbol.sdk.model.transaction.MultisigAccountModificationTransactionFactory;
 import io.nem.symbol.sdk.model.transaction.SignedTransaction;
@@ -47,8 +60,12 @@ import io.nem.symbol.sdk.model.transaction.TransactionStatusException;
 import io.nem.symbol.sdk.model.transaction.TransactionType;
 import io.nem.symbol.sdk.model.transaction.TransferTransaction;
 import io.nem.symbol.sdk.model.transaction.TransferTransactionFactory;
+import io.nem.symbol.sdk.model.transaction.VrfKeyLinkTransaction;
+import io.nem.symbol.sdk.model.transaction.VrfKeyLinkTransactionFactory;
 import io.nem.symbol.sdk.openapi.vertx.model.Cosignature;
 import io.nem.symbol.sdk.openapi.vertx.model.TransactionInfoDTO;
+import io.reactivex.Observable;
+import io.reactivex.ObservableSource;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.buffer.impl.BufferFactoryImpl;
@@ -57,19 +74,24 @@ import io.vertx.core.http.RequestOptions;
 import io.vertx.core.http.WebSocket;
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
@@ -78,6 +100,7 @@ import org.mockito.Mockito;
  */
 public class ListenerVertxTest {
 
+    public static final NetworkType NETWORK_TYPE = NetworkType.MIJIN_TEST;
     private ListenerVertx listener;
 
     private HttpClient httpClientMock;
@@ -142,95 +165,13 @@ public class ListenerVertxTest {
         Mockito.verify(webSocketMock).close();
     }
 
-    @Test
-    public void shouldHandleTransaction()
-        throws InterruptedException, ExecutionException, TimeoutException {
-        simulateWebSocketStartup();
-
-        TransactionInfoDTO transactionInfo = TestHelperVertx.loadTransactionInfoDTO(
-            "aggregateMosaicCreationTransaction.json");
-
-        ObjectNode transactionInfoDtoJsonObject = jsonHelper
-            .convert(transactionInfo, ObjectNode.class);
-
-        Address address = Address.createFromPublicKey(
-            jsonHelper.getString(transactionInfoDtoJsonObject, "transaction", "signerPublicKey"),
-            NetworkType.MIJIN_TEST);
-
-        String channelName = ListenerChannel.CONFIRMED_ADDED.toString();
-
-        ((ObjectNode) transactionInfoDtoJsonObject.get("meta")).put("channelName", channelName);
-
-        List<Transaction> transactions = new ArrayList<>();
-        List<Throwable> exceptions = new ArrayList<>();
-        listener.confirmed(address, transactionInfo.getMeta().getHash()).doOnError(exceptions::add)
-            .forEach(transactions::add);
-
-        listener.handle(transactionInfoDtoJsonObject, null);
-
-        Assertions.assertEquals(1, transactions.size());
-        Assertions.assertEquals(0, exceptions.size());
-
-        Assertions.assertEquals(address, transactions.get(0).getSigner().get().getAddress());
-
-        Mockito.verify(webSocketMock).handler(Mockito.any());
-        Mockito.verify(webSocketMock)
-            .writeTextMessage(jsonHelper.print(new ListenerSubscribeMessage(this.wsId,
-                channelName + "/" + address.plain())));
-        Mockito.verify(webSocketMock).writeTextMessage(jsonHelper
-            .print(new ListenerSubscribeMessage(this.wsId, "status" + "/" + address.plain())));
-
-    }
-
-    @Test
-    public void confirmedUsingHash()
-        throws InterruptedException, ExecutionException, TimeoutException {
-        simulateWebSocketStartup();
-
-        TransactionInfoDTO transactionInfo = TestHelperVertx.loadTransactionInfoDTO(
-            "aggregateMosaicCreationTransaction.json");
-
-        ObjectNode transactionInfoDtoJsonObject = jsonHelper
-            .convert(transactionInfo, ObjectNode.class);
-
-        Address address = Address.createFromPublicKey(
-            jsonHelper.getString(transactionInfoDtoJsonObject, "transaction", "signerPublicKey"),
-            NetworkType.MIJIN_TEST);
-
-        String channelName = ListenerChannel.CONFIRMED_ADDED.toString();
-
-        ((ObjectNode) transactionInfoDtoJsonObject.get("meta"))
-            .put("channelName", channelName);
-
-        List<Transaction> transactions = new ArrayList<>();
-        List<Throwable> exceptions = new ArrayList<>();
-        listener.confirmed(address, transactionInfo.getMeta().getHash()).doOnError(exceptions::add)
-            .forEach(transactions::add);
-
-        listener.handle(transactionInfoDtoJsonObject, null);
-
-        Assertions.assertEquals(1, transactions.size());
-        Assertions.assertEquals(0, exceptions.size());
-
-        Assertions.assertEquals(address, transactions.get(0).getSigner().get().getAddress());
-
-        Mockito.verify(webSocketMock).handler(Mockito.any());
-        Mockito.verify(webSocketMock)
-            .writeTextMessage(jsonHelper.print(new ListenerSubscribeMessage(this.wsId,
-                channelName + "/" + address.plain())));
-
-        Mockito.verify(webSocketMock).writeTextMessage(jsonHelper
-            .print(new ListenerSubscribeMessage(this.wsId, "status" + "/" + address.plain())));
-
-    }
-
 
     @Test
     public void cosignatureAdded()
         throws InterruptedException, ExecutionException, TimeoutException {
         simulateWebSocketStartup();
-
-        NetworkType networkType = NetworkType.MIJIN_TEST;
+        ListenerChannel consignature = ListenerChannel.COSIGNATURE;
+        NetworkType networkType = NETWORK_TYPE;
         Cosignature cosignature = new Cosignature().parentHash("aParentHash")
             .signature("aSignature")
             .signerPublicKey(Account.generateNewAccount(networkType).getPublicKey());
@@ -241,7 +182,7 @@ public class ListenerVertxTest {
         Address address = Address.createFromPublicKey(cosignature.getSignerPublicKey(),
             networkType);
 
-        String channelName = ListenerChannel.COSIGNATURE.toString();
+        String channelName = consignature.toString();
 
         List<CosignatureSignedTransaction> transactions = new ArrayList<>();
         listener.cosignatureAdded(address).forEach(transactions::add);
@@ -260,8 +201,9 @@ public class ListenerVertxTest {
                 channelName + "/" + address.plain())));
     }
 
-    @Test
-    public void confirmedUsingHashRaiseError()
+    @ParameterizedTest
+    @ValueSource(strings = {"CONFIRMED_ADDED", "AGGREGATE_BONDED_ADDED"})
+    public void subscribeValid(ListenerChannel channel)
         throws InterruptedException, ExecutionException, TimeoutException {
         simulateWebSocketStartup();
 
@@ -273,43 +215,41 @@ public class ListenerVertxTest {
 
         Address address = Address.createFromPublicKey(
             jsonHelper.getString(transactionInfoDtoJsonObject, "transaction", "signerPublicKey"),
-            NetworkType.MIJIN_TEST);
+            NETWORK_TYPE);
 
-        String channelName = ListenerChannel.CONFIRMED_ADDED.toString();
+        String channelName = channel.toString();
 
-        Map<String, Object> transactionStatusError = new HashMap<>();
-        transactionStatusError.put("address", address.encoded());
-        transactionStatusError.put("code", "Fail 666");
-        transactionStatusError.put("hash", transactionInfo.getMeta().getHash());
-        transactionStatusError.put("deadline", 123);
+        ((ObjectNode) transactionInfoDtoJsonObject.get("meta")).put("channelName", channelName);
 
         List<Transaction> transactions = new ArrayList<>();
         List<Throwable> exceptions = new ArrayList<>();
-        listener.confirmed(address, transactionInfo.getMeta().getHash()).doOnError(exceptions::add)
+        BiFunction<Address, String, Observable<? extends Transaction>> subscriber =
+            channel == ListenerChannel.CONFIRMED_ADDED ? listener::confirmedOrError
+                : listener::aggregateBondedAddedOrError;
+
+        subscriber.apply(address, transactionInfo.getMeta().getHash())
+            .doOnError(exceptions::add)
             .forEach(transactions::add);
 
-        listener.handle(transactionStatusError, null);
+        listener.handle(transactionInfoDtoJsonObject, null);
 
-        Assertions.assertEquals(0, transactions.size());
-        Assertions.assertEquals(1, exceptions.size());
-        Assertions.assertEquals(TransactionStatusException.class, exceptions.get(0).getClass());
-        Assertions
-            .assertEquals("Fail 666 processing transaction " + transactionInfo.getMeta().getHash(),
-                exceptions.get(0).getMessage());
+        Assertions.assertEquals(1, transactions.size());
+        Assertions.assertEquals(0, exceptions.size());
+
+        Assertions.assertEquals(address, transactions.get(0).getSigner().get().getAddress());
 
         Mockito.verify(webSocketMock).handler(Mockito.any());
         Mockito.verify(webSocketMock)
             .writeTextMessage(jsonHelper.print(new ListenerSubscribeMessage(this.wsId,
                 channelName + "/" + address.plain())));
-
-        Mockito.verify(webSocketMock)
-            .writeTextMessage(jsonHelper
-                .print(new ListenerSubscribeMessage(this.wsId, "status" + "/" + address.plain())));
+        Mockito.verify(webSocketMock).writeTextMessage(jsonHelper
+            .print(new ListenerSubscribeMessage(this.wsId, "status" + "/" + address.plain())));
 
     }
 
-    @Test
-    public void aggregateBondedAddedUsingHash()
+    @ParameterizedTest
+    @ValueSource(strings = {"CONFIRMED_ADDED", "AGGREGATE_BONDED_ADDED"})
+    public void subscribeOnHash(ListenerChannel channel)
         throws InterruptedException, ExecutionException, TimeoutException {
         simulateWebSocketStartup();
 
@@ -321,16 +261,21 @@ public class ListenerVertxTest {
 
         Address address = Address.createFromPublicKey(
             jsonHelper.getString(transactionInfoDtoJsonObject, "transaction", "signerPublicKey"),
-            NetworkType.MIJIN_TEST);
+            NETWORK_TYPE);
 
-        String channelName = ListenerChannel.AGGREGATE_BONDED_ADDED.toString();
+        String channelName = channel.toString();
 
         ((ObjectNode) transactionInfoDtoJsonObject.get("meta"))
             .put("channelName", channelName);
 
         List<Transaction> transactions = new ArrayList<>();
         List<Throwable> exceptions = new ArrayList<>();
-        listener.aggregateBondedAdded(address, transactionInfo.getMeta().getHash())
+
+        BiFunction<Address, String, Observable<? extends Transaction>> subscriber =
+            channel == ListenerChannel.CONFIRMED_ADDED ? listener::confirmedOrError
+                : listener::aggregateBondedAddedOrError;
+
+        subscriber.apply(address, transactionInfo.getMeta().getHash())
             .doOnError(exceptions::add)
             .forEach(transactions::add);
 
@@ -351,11 +296,143 @@ public class ListenerVertxTest {
 
     }
 
-    @Test
-    public void aggregateBondedAddedUsingHashOnError()
+    @ParameterizedTest
+    @ValueSource(strings = {"CONFIRMED_ADDED", "AGGREGATE_BONDED_ADDED", "UNCONFIRMED_ADDED"})
+    public void subscribeAlias(ListenerChannel channel)
         throws InterruptedException, ExecutionException, TimeoutException {
+        String channelName = channel.toString();
+        simulateWebSocketStartup();
+        TransactionInfoDTO transactionInfo = TestHelperVertx.loadTransactionInfoDTO(
+            "transferEmptyMessage.json");
+
+        NamespaceId namespaceId = NamespaceId.createFromName("alias");
+
+        ObjectNode transactionInfoDtoJsonObject = jsonHelper
+            .convert(transactionInfo, ObjectNode.class);
+
+        ((ObjectNode) transactionInfoDtoJsonObject.get("meta")).put("channelName", channelName);
+
+        ((ObjectNode) transactionInfoDtoJsonObject.get("transaction")).put("recipientAddress",
+            ConvertUtils.toHex(
+                SerializationUtils.toUnresolvedAddress(namespaceId, NETWORK_TYPE)
+                    .serialize()));
+
+        Address address = Account.generateNewAccount(NETWORK_TYPE).getAddress();
+
+        Mockito.when(
+            namespaceRepository.getAccountsNames(Mockito.eq(Collections.singletonList(address))))
+            .thenReturn(
+                Observable.just(Collections.singletonList(new AccountNames(address,
+                    Collections.singletonList(new NamespaceName(namespaceId, "alias")))))
+            );
+
+        ((ObjectNode) transactionInfoDtoJsonObject.get("meta")).put("channelName", channelName);
+
+        List<Transaction> transactions = new ArrayList<>();
+
+        BiFunction<Address, String, Observable<? extends Transaction>> subscriber =
+            channel == ListenerChannel.CONFIRMED_ADDED ? listener::confirmed
+                : channel == ListenerChannel.UNCONFIRMED_ADDED ? listener::unconfirmedAdded
+                    : listener::aggregateBondedAdded;
+
+        subscriber.apply(address, transactionInfo.getMeta().getHash())
+            .forEach(transactions::add);
+
+        listener.handle(transactionInfoDtoJsonObject, null);
+
+        Assertions.assertEquals(1, transactions.size());
+
+        Mockito.verify(webSocketMock).handler(Mockito.any());
+        Mockito.verify(webSocketMock)
+            .writeTextMessage(jsonHelper.print(new ListenerSubscribeMessage(this.wsId,
+                channelName + "/" + address.plain())));
+
+        Mockito.verify(webSocketMock)
+            .writeTextMessage(jsonHelper
+                .print(
+                    new ListenerSubscribeMessage(this.wsId, channelName + "/" + address.plain())));
+
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(strings = {"AGGREGATE_BONDED_REMOVED", "UNCONFIRMED_REMOVED"})
+    public void subscribeToHash(ListenerChannel channel)
+        throws InterruptedException, ExecutionException, TimeoutException {
+        String channelName = channel.toString();
         simulateWebSocketStartup();
 
+        Address address = Account.generateNewAccount(NETWORK_TYPE).getAddress();
+
+        String hash = "someHash";
+        List<String> hashes = new ArrayList<>();
+        BiFunction<Address, String, Observable<String>> subscriber =
+            channel == ListenerChannel.AGGREGATE_BONDED_REMOVED ? listener::aggregateBondedRemoved
+                : listener::unconfirmedRemoved;
+
+        subscriber.apply(address, hash).forEach(hashes::add);
+
+        Map<String, Map<String, String>> message = new HashMap<>();
+        Map<String, String> meta = new HashMap<>();
+        meta.put("channelName", channel.toString());
+        meta.put("hash", hash);
+        message.put("meta", meta);
+        listener.handle(message, null);
+
+        Assertions.assertEquals(1, hashes.size());
+        Assertions.assertEquals(hash, hashes.get(0));
+
+        Mockito.verify(webSocketMock).handler(Mockito.any());
+        Mockito.verify(webSocketMock)
+            .writeTextMessage(jsonHelper.print(new ListenerSubscribeMessage(this.wsId,
+                channelName + "/" + address.plain())));
+
+        Mockito.verify(webSocketMock)
+            .writeTextMessage(jsonHelper
+                .print(
+                    new ListenerSubscribeMessage(this.wsId, channelName + "/" + address.plain())));
+
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"AGGREGATE_BONDED_REMOVED", "UNCONFIRMED_REMOVED"})
+    public void subscribeToHashWhenInvalidHash(ListenerChannel channel)
+        throws InterruptedException, ExecutionException, TimeoutException {
+        String channelName = channel.toString();
+        simulateWebSocketStartup();
+        Address address = Account.generateNewAccount(NETWORK_TYPE).getAddress();
+        String hash = "someHash";
+        List<String> hashes = new ArrayList<>();
+        BiFunction<Address, String, Observable<String>> subscriber =
+            channel == ListenerChannel.AGGREGATE_BONDED_REMOVED ? listener::aggregateBondedRemoved
+                : listener::unconfirmedRemoved;
+        subscriber.apply(address, hash).forEach(hashes::add);
+        Map<String, Map<String, String>> message = new HashMap<>();
+        Map<String, String> meta = new HashMap<>();
+        meta.put("channelName", channel.toString());
+        meta.put("hash", "invalidHash");
+        message.put("meta", meta);
+        listener.handle(message, null);
+
+        Assertions.assertEquals(0, hashes.size());
+
+        Mockito.verify(webSocketMock).handler(Mockito.any());
+        Mockito.verify(webSocketMock)
+            .writeTextMessage(jsonHelper.print(new ListenerSubscribeMessage(this.wsId,
+                channelName + "/" + address.plain())));
+
+        Mockito.verify(webSocketMock)
+            .writeTextMessage(jsonHelper
+                .print(
+                    new ListenerSubscribeMessage(this.wsId, channelName + "/" + address.plain())));
+
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"CONFIRMED_ADDED", "AGGREGATE_BONDED_ADDED"})
+    public void subscribeOnError(ListenerChannel channel)
+        throws InterruptedException, ExecutionException, TimeoutException {
+        simulateWebSocketStartup();
         TransactionInfoDTO transactionInfo = TestHelperVertx.loadTransactionInfoDTO(
             "aggregateMosaicCreationTransaction.json");
 
@@ -364,9 +441,9 @@ public class ListenerVertxTest {
 
         Address address = Address.createFromPublicKey(
             jsonHelper.getString(transactionInfoDtoJsonObject, "transaction", "signerPublicKey"),
-            NetworkType.MIJIN_TEST);
+            NETWORK_TYPE);
 
-        String channelName = ListenerChannel.AGGREGATE_BONDED_ADDED.toString();
+        String channelName = channel.toString();
 
         Map<String, Object> transactionStatusError = new HashMap<>();
         transactionStatusError.put("address", address.encoded());
@@ -376,7 +453,12 @@ public class ListenerVertxTest {
 
         List<Transaction> transactions = new ArrayList<>();
         List<Throwable> exceptions = new ArrayList<>();
-        listener.aggregateBondedAdded(address, transactionInfo.getMeta().getHash())
+
+        BiFunction<Address, String, Observable<? extends Transaction>> subscriber =
+            channel == ListenerChannel.CONFIRMED_ADDED ? listener::confirmedOrError
+                : listener::aggregateBondedAddedOrError;
+
+        subscriber.apply(address, transactionInfo.getMeta().getHash())
             .doOnError(exceptions::add)
             .forEach(transactions::add);
 
@@ -429,91 +511,114 @@ public class ListenerVertxTest {
 
     @Test
     public void shouldCheckTransactionFromAddressTransferTransaction() {
-        Account account1 = Account.generateNewAccount(NetworkType.MIJIN_TEST);
-        Account account2 = Account.generateNewAccount(NetworkType.MIJIN_TEST);
-        Account account3 = Account.generateNewAccount(NetworkType.MIJIN_TEST);
+        Account account1 = Account.generateNewAccount(NETWORK_TYPE);
+        Account account2 = Account.generateNewAccount(NETWORK_TYPE);
+        Account account3 = Account.generateNewAccount(NETWORK_TYPE);
 
-        Assertions.assertTrue(listener
-            .transactionFromAddress(
+        Assertions.assertTrue(
+            transactionFromAddress(listener,
                 transferTransaction(account1.getPublicAccount(), account3.getAddress()),
                 account1.getAddress()));
 
-        Assertions.assertFalse(listener
-            .transactionFromAddress(
-                transferTransaction(account2.getPublicAccount(), account3.getAddress()),
+        Assertions.assertFalse(transactionFromAddress(listener,
+            transferTransaction(account2.getPublicAccount(), account3.getAddress()),
+            account1.getAddress()));
+
+        Assertions.assertFalse(
+            transactionFromAddress(listener, transferTransaction(null, account3.getAddress()),
                 account1.getAddress()));
 
-        Assertions.assertFalse(listener
-            .transactionFromAddress(transferTransaction(null, account3.getAddress()),
-                account1.getAddress()));
+        Assertions.assertTrue(transactionFromAddress(listener,
+            transferTransaction(account1.getPublicAccount(), account3.getAddress()),
+            account3.getAddress()));
 
-        Assertions.assertTrue(listener
-            .transactionFromAddress(
-                transferTransaction(account1.getPublicAccount(), account3.getAddress()),
+        Assertions.assertTrue(transactionFromAddress(listener,
+            transferTransaction(account2.getPublicAccount(), account3.getAddress()),
+            account3.getAddress()));
+
+        Assertions.assertTrue(
+            transactionFromAddress(listener, transferTransaction(null, account3.getAddress()),
                 account3.getAddress()));
 
-        Assertions.assertTrue(listener
-            .transactionFromAddress(
-                transferTransaction(account2.getPublicAccount(), account3.getAddress()),
-                account3.getAddress()));
+        Assertions.assertTrue(
+            transactionFromAddress(listener,
+                transferTransaction(account2.getPublicAccount(),
+                    NamespaceId.createFromName("alias")),
+                account3.getAddress(),
+                NamespaceId.createFromName("alias")));
 
-        Assertions.assertTrue(listener
-            .transactionFromAddress(transferTransaction(null, account3.getAddress()),
-                account3.getAddress()));
+        Assertions.assertFalse(
+            transactionFromAddress(listener,
+                transferTransaction(account2.getPublicAccount(),
+                    NamespaceId.createFromName("alias")),
+                account3.getAddress(),
+                NamespaceId.createFromName("alias2")));
 
+    }
+
+
+    private boolean transactionFromAddress(ListenerVertx listener, Transaction transferTransaction,
+        Address address, NamespaceId... aliases) {
+        try {
+            Callable<ObservableSource<? extends List<NamespaceId>>> restCall = () -> Observable
+                .just(Arrays.asList(aliases));
+            Observable<List<NamespaceId>> namespaceIdObservable = Observable
+                .defer(restCall).cache();
+            return listener
+                .transactionFromAddress(transferTransaction, address, namespaceIdObservable)
+                .toFuture()
+                .get();
+        } catch (Exception e) {
+            throw new IllegalStateException(e.getMessage(), e);
+        }
     }
 
 
     @Test
     public void shouldCheckMultisigAccountModificationTransaction() {
-        Account account1 = Account.generateNewAccount(NetworkType.MIJIN_TEST);
-        Account account2 = Account.generateNewAccount(NetworkType.MIJIN_TEST);
-        Account account3 = Account.generateNewAccount(NetworkType.MIJIN_TEST);
+        Account account1 = Account.generateNewAccount(NETWORK_TYPE);
+        Account account2 = Account.generateNewAccount(NETWORK_TYPE);
+        Account account3 = Account.generateNewAccount(NETWORK_TYPE);
 
-        Assertions.assertTrue(listener
-            .transactionFromAddress(
-                multisigAccountModificationTransaction(account1.getPublicAccount(),
-                    account3.getPublicAccount()),
-                account1.getAddress()));
+        Assertions.assertTrue(transactionFromAddress(listener,
+            multisigAccountModificationTransaction(account1.getPublicAccount(),
+                account3.getPublicAccount()),
+            account1.getAddress()));
 
-        Assertions.assertFalse(listener
-            .transactionFromAddress(
+        Assertions.assertFalse(
+            transactionFromAddress(listener,
                 multisigAccountModificationTransaction(account2.getPublicAccount(),
 
                     account3.getPublicAccount()),
                 account1.getAddress()));
 
-        Assertions.assertFalse(listener
-            .transactionFromAddress(
-                multisigAccountModificationTransaction(null,
-                    account3.getPublicAccount()),
-                account1.getAddress()));
+        Assertions.assertFalse(transactionFromAddress(listener,
+            multisigAccountModificationTransaction(null,
+                account3.getPublicAccount()),
+            account1.getAddress()));
 
-        Assertions.assertTrue(listener
-            .transactionFromAddress(
-                multisigAccountModificationTransaction(account1.getPublicAccount(),
+        Assertions.assertTrue(transactionFromAddress(listener,
+            multisigAccountModificationTransaction(account1.getPublicAccount(),
 
-                    account3.getPublicAccount()),
-                account3.getAddress()));
+                account3.getPublicAccount()),
+            account3.getAddress()));
 
-        Assertions.assertTrue(listener
-            .transactionFromAddress(
-                multisigAccountModificationTransaction(account2.getPublicAccount(),
+        Assertions.assertTrue(transactionFromAddress(listener,
+            multisigAccountModificationTransaction(account2.getPublicAccount(),
 
-                    account3.getPublicAccount()),
-                account3.getAddress()));
+                account3.getPublicAccount()),
+            account3.getAddress()));
 
-        Assertions.assertTrue(listener
-            .transactionFromAddress(
-                multisigAccountModificationTransaction(null,
-                    account3.getPublicAccount()),
-                account3.getAddress()));
+        Assertions.assertTrue(transactionFromAddress(listener,
+            multisigAccountModificationTransaction(null,
+                account3.getPublicAccount()),
+            account3.getAddress()));
     }
 
     @Test
     public void shouldHandleStatus()
         throws InterruptedException, ExecutionException, TimeoutException {
-        Account account1 = Account.generateNewAccount(NetworkType.MIJIN_TEST);
+        Account account1 = Account.generateNewAccount(NETWORK_TYPE);
 
         AtomicReference<TransactionStatusError> reference = new AtomicReference<>();
 
@@ -539,15 +644,13 @@ public class ListenerVertxTest {
         Mockito.verify(webSocketMock).writeTextMessage(jsonHelper
             .print(new ListenerSubscribeMessage(this.wsId,
                 "status" + "/" + account1.getAddress().plain())));
-
-
     }
 
     @Test
     public void shouldFilterOutHandleStatus()
         throws InterruptedException, ExecutionException, TimeoutException {
-        Account account1 = Account.generateNewAccount(NetworkType.MIJIN_TEST);
-        Account account2 = Account.generateNewAccount(NetworkType.MIJIN_TEST);
+        Account account1 = Account.generateNewAccount(NETWORK_TYPE);
+        Account account2 = Account.generateNewAccount(NETWORK_TYPE);
 
         AtomicReference<TransactionStatusError> reference = new AtomicReference<>();
 
@@ -573,28 +676,84 @@ public class ListenerVertxTest {
 
     @Test
     public void shouldCheckTransactionFromAddressHashLockTransaction() {
-        Account account1 = Account.generateNewAccount(NetworkType.MIJIN_TEST);
-        Account account2 = Account.generateNewAccount(NetworkType.MIJIN_TEST);
-        Assertions.assertTrue(listener
-            .transactionFromAddress(hashLockTransaction(account1.getPublicAccount()),
+        Account account1 = Account.generateNewAccount(NETWORK_TYPE);
+        Account account2 = Account.generateNewAccount(NETWORK_TYPE);
+        Assertions.assertTrue(
+            transactionFromAddress(listener, hashLockTransaction(account1.getPublicAccount()),
                 account1.getAddress()));
 
-        Assertions.assertFalse(listener
-            .transactionFromAddress(hashLockTransaction(account2.getPublicAccount()),
+        Assertions.assertFalse(
+            transactionFromAddress(listener, hashLockTransaction(account2.getPublicAccount()),
                 account1.getAddress()));
 
-        Assertions.assertFalse(listener
-            .transactionFromAddress(hashLockTransaction(null),
+        Assertions.assertFalse(
+            transactionFromAddress(listener, hashLockTransaction(null),
                 account1.getAddress()));
 
     }
 
-    private TransferTransaction transferTransaction(PublicAccount signer, Address recipient) {
+    private TransferTransaction transferTransaction(PublicAccount signer,
+        UnresolvedAddress recipient) {
         TransferTransactionFactory factory = TransferTransactionFactory
-            .create(NetworkType.MIJIN_TEST,
+            .create(NETWORK_TYPE,
                 recipient,
                 Collections.emptyList(),
                 PlainMessage.Empty);
+        if (signer != null) {
+            factory.signer(signer);
+        }
+        return factory.build();
+    }
+
+    @Test
+    public void shouldCheckVrfKeyLinkTransaction() {
+        Account account1 = Account.generateNewAccount(NETWORK_TYPE);
+        Account account2 = Account.generateNewAccount(NETWORK_TYPE);
+        Assertions.assertTrue(
+            transactionFromAddress(listener,
+                vrfKeyLinkTransaction(account2.getPublicAccount(),
+                    account1.getPublicAccount().getPublicKey()),
+                account1.getAddress()));
+
+        Assertions.assertFalse(
+            transactionFromAddress(listener,
+                vrfKeyLinkTransaction(account2.getPublicAccount(),
+                    account2.getPublicAccount().getPublicKey()),
+                account1.getAddress()));
+
+    }
+
+    private VrfKeyLinkTransaction vrfKeyLinkTransaction(PublicAccount signer,
+        PublicKey linkedAccount) {
+        VrfKeyLinkTransactionFactory factory = VrfKeyLinkTransactionFactory
+            .create(NETWORK_TYPE, linkedAccount, LinkAction.LINK);
+        if (signer != null) {
+            factory.signer(signer);
+        }
+        return factory.build();
+    }
+
+    @Test
+    public void shouldCheckAccountMetadataTransaction() {
+        Account account1 = Account.generateNewAccount(NETWORK_TYPE);
+        Account account2 = Account.generateNewAccount(NETWORK_TYPE);
+        Assertions.assertTrue(
+            transactionFromAddress(listener,
+                accountMetadataTransaction(account2.getPublicAccount(),
+                    account1.getPublicAccount()),
+                account1.getAddress()));
+
+        Assertions.assertFalse(
+            transactionFromAddress(listener,
+                accountMetadataTransaction(account2.getPublicAccount(),
+                    account2.getPublicAccount()),
+                account1.getAddress()));
+    }
+
+    private AccountMetadataTransaction accountMetadataTransaction(PublicAccount signer,
+        PublicAccount targetAccount) {
+        AccountMetadataTransactionFactory factory = AccountMetadataTransactionFactory
+            .create(NETWORK_TYPE, targetAccount, BigInteger.ONE, "someValue");
         if (signer != null) {
             factory.signer(signer);
         }
@@ -608,7 +767,7 @@ public class ListenerVertxTest {
         List<PublicAccount> deletions = Collections.singletonList(cosignatoryPublicAccount);
 
         MultisigAccountModificationTransactionFactory factory = MultisigAccountModificationTransactionFactory
-            .create(NetworkType.MIJIN_TEST, (byte) 0, (byte) 0, additions, deletions);
+            .create(NETWORK_TYPE, (byte) 0, (byte) 0, additions, deletions);
         if (signer != null) {
             factory.signer(signer);
         }
@@ -616,87 +775,218 @@ public class ListenerVertxTest {
     }
 
     @Test
-    public void shouldCheckTransactionAggregateTransaction() {
-        Account account1 = Account.generateNewAccount(NetworkType.MIJIN_TEST);
-        Account account2 = Account.generateNewAccount(NetworkType.MIJIN_TEST);
-        Account account3 = Account.generateNewAccount(NetworkType.MIJIN_TEST);
-        Transaction anotherTransaction = hashLockTransaction(account2.getPublicAccount());
-        Assertions.assertTrue(listener
-            .transactionFromAddress(
-                aggregateTransaction(account1.getPublicAccount(),
-                    anotherTransaction, account3.getPublicAccount()),
+    public void shouldAccountAddressRestrictionTransaction() {
+        Account account1 = Account.generateNewAccount(NETWORK_TYPE);
+        Account account2 = Account.generateNewAccount(NETWORK_TYPE);
+        Account account3 = Account.generateNewAccount(NETWORK_TYPE);
+        Account account4 = Account.generateNewAccount(NETWORK_TYPE);
+        NamespaceId alias1 = NamespaceId.createFromName("alias1");
+        NamespaceId alias2 = NamespaceId.createFromName("alias2");
+
+        Assertions.assertTrue(
+            transactionFromAddress(listener,
+                accountAddressRestrictionTransaction(account1.getPublicAccount(),
+                    account2.getAddress(), account3.getAddress()),
                 account1.getAddress()));
 
-        Assertions.assertFalse(listener
-            .transactionFromAddress(
-                aggregateTransaction(account2.getPublicAccount(),
-                    anotherTransaction,
-                    account3.getPublicAccount()),
-                account1.getAddress()));
-
-        Assertions.assertFalse(listener
-            .transactionFromAddress(
-                aggregateTransaction(null, anotherTransaction,
-                    account3.getPublicAccount()),
-                account1.getAddress()));
-
-        Assertions.assertTrue(listener
-            .transactionFromAddress(
-                aggregateTransaction(account1.getPublicAccount(),
-                    anotherTransaction,
-                    account3.getPublicAccount()),
-                account3.getAddress()));
-
-        Assertions.assertTrue(listener
-            .transactionFromAddress(
-                aggregateTransaction(account2.getPublicAccount(),
-                    anotherTransaction,
-                    account3.getPublicAccount()),
-                account3.getAddress()));
-
-        Assertions.assertTrue(listener
-            .transactionFromAddress(
-                aggregateTransaction(null, anotherTransaction,
-                    account3.getPublicAccount()),
-                account3.getAddress()));
-
-        Assertions.assertTrue(listener
-            .transactionFromAddress(
-                aggregateTransaction(account1.getPublicAccount(),
-                    anotherTransaction,
-                    account3.getPublicAccount()),
-                account3.getAddress()));
-
-        Assertions.assertFalse(listener
-            .transactionFromAddress(
-                aggregateTransaction(account1.getPublicAccount(),
-                    anotherTransaction,
-                    account2.getPublicAccount()),
-                account3.getAddress()));
-
-        Assertions.assertTrue(listener
-            .transactionFromAddress(
-                aggregateTransaction(account2.getPublicAccount(),
-                    anotherTransaction,
-                    account3.getPublicAccount()),
+        Assertions.assertTrue(
+            transactionFromAddress(listener,
+                accountAddressRestrictionTransaction(account1.getPublicAccount(),
+                    account2.getAddress(), account3.getAddress()),
                 account2.getAddress()));
 
-        Assertions.assertFalse(listener
-            .transactionFromAddress(
-                aggregateTransaction(null,
-                    anotherTransaction,
-                    account2.getPublicAccount()),
+        Assertions.assertTrue(
+            transactionFromAddress(listener,
+                accountAddressRestrictionTransaction(account1.getPublicAccount(),
+                    account2.getAddress(), account3.getAddress()),
                 account3.getAddress()));
+
+        Assertions.assertFalse(
+            transactionFromAddress(listener,
+                accountAddressRestrictionTransaction(account1.getPublicAccount(),
+                    account2.getAddress(), account3.getAddress()),
+                account4.getAddress()));
+
+        Assertions.assertTrue(
+            transactionFromAddress(listener,
+                accountAddressRestrictionTransaction(account1.getPublicAccount(),
+                    alias1, account3.getAddress()),
+                account2.getAddress(), alias1));
+
+        Assertions.assertTrue(
+            transactionFromAddress(listener,
+                accountAddressRestrictionTransaction(account1.getPublicAccount(),
+                    account2.getAddress(), alias1),
+                account3.getAddress(), alias1));
+
+        Assertions.assertFalse(
+            transactionFromAddress(listener,
+                accountAddressRestrictionTransaction(account1.getPublicAccount(),
+                    alias1, account3.getAddress()),
+                account2.getAddress(), alias2));
+
+        Assertions.assertFalse(
+            transactionFromAddress(listener,
+                accountAddressRestrictionTransaction(account1.getPublicAccount(),
+                    account2.getAddress(), alias1),
+                account3.getAddress(), alias2));
+    }
+
+    private AccountAddressRestrictionTransaction accountAddressRestrictionTransaction(
+        PublicAccount signer,
+        UnresolvedAddress addition, UnresolvedAddress deletion) {
+        List<UnresolvedAddress> additions = Collections.singletonList(addition);
+        List<UnresolvedAddress> deletions = Collections.singletonList(deletion);
+
+        AccountAddressRestrictionTransactionFactory factory = AccountAddressRestrictionTransactionFactory
+            .create(NETWORK_TYPE, AccountRestrictionFlags.BLOCK_ADDRESS, additions, deletions);
+        if (signer != null) {
+            factory.signer(signer);
+        }
+        return factory.build();
+    }
+
+
+    @Test
+    public void shouldCheckTransactionAggregateTransaction() {
+
+        Account account1 = Account.generateNewAccount(NETWORK_TYPE);
+        Account account2 = Account.generateNewAccount(NETWORK_TYPE);
+        Account account3 = Account.generateNewAccount(NETWORK_TYPE);
+        NamespaceId alias1 = NamespaceId.createFromName("alias1");
+        NamespaceId alias2 = NamespaceId.createFromName("alias2");
+        Transaction hashLockTransaction = hashLockTransaction(account2.getPublicAccount());
+        Transaction transferTransaction1 = transferTransaction(account2.getPublicAccount(), alias1);
+        Transaction transferTransaction2 = transferTransaction(account2.getPublicAccount(), alias2);
+
+        Assertions.assertTrue(transactionFromAddress(listener,
+            aggregateTransaction(account1.getPublicAccount(),
+                account3.getPublicAccount(), hashLockTransaction),
+            account1.getAddress()));
+
+        Assertions.assertFalse(transactionFromAddress(listener,
+            aggregateTransaction(account2.getPublicAccount(),
+                account3.getPublicAccount(), hashLockTransaction
+            ),
+            account1.getAddress()));
+
+        Assertions.assertFalse(transactionFromAddress(listener,
+            aggregateTransaction(null, account3.getPublicAccount(), hashLockTransaction
+            ),
+            account1.getAddress()));
+
+        Assertions.assertTrue(transactionFromAddress(listener,
+            aggregateTransaction(account1.getPublicAccount(),
+                account3.getPublicAccount(), hashLockTransaction
+            ),
+            account3.getAddress()));
+
+        Assertions.assertTrue(transactionFromAddress(listener,
+            aggregateTransaction(account2.getPublicAccount(),
+                account3.getPublicAccount(), hashLockTransaction
+            ),
+            account3.getAddress()));
+
+        Assertions.assertTrue(transactionFromAddress(listener,
+            aggregateTransaction(null, account3.getPublicAccount(), hashLockTransaction
+            ),
+            account3.getAddress()));
+
+        Assertions.assertTrue(transactionFromAddress(listener,
+            aggregateTransaction(account1.getPublicAccount(),
+                account3.getPublicAccount(), hashLockTransaction
+            ),
+            account3.getAddress()));
+
+        Assertions.assertFalse(transactionFromAddress(listener,
+            aggregateTransaction(account1.getPublicAccount(),
+                account2.getPublicAccount(), hashLockTransaction
+            ),
+            account3.getAddress()));
+
+        Assertions.assertTrue(transactionFromAddress(listener,
+            aggregateTransaction(account2.getPublicAccount(),
+                account3.getPublicAccount(), hashLockTransaction
+            ),
+            account2.getAddress()));
+
+        Assertions.assertFalse(transactionFromAddress(listener,
+            aggregateTransaction(null,
+                account2.getPublicAccount(), hashLockTransaction
+            ),
+            account3.getAddress()));
+
+        Assertions.assertFalse(transactionFromAddress(listener,
+            aggregateTransaction(null,
+                account2.getPublicAccount(),
+                hashLockTransaction,
+                transferTransaction1,
+                transferTransaction2
+            ),
+            account3.getAddress()));
+
+        Assertions.assertTrue(transactionFromAddress(listener,
+            aggregateTransaction(null,
+                account2.getPublicAccount(),
+                hashLockTransaction,
+                transferTransaction1,
+                transferTransaction2
+            ),
+            account3.getAddress(), alias2));
+
+        Assertions.assertTrue(transactionFromAddress(listener,
+            aggregateTransaction(null,
+                account2.getPublicAccount(),
+                hashLockTransaction,
+                transferTransaction2
+            ),
+            account3.getAddress(), alias2));
+
+        Assertions.assertFalse(transactionFromAddress(listener,
+            aggregateTransaction(null,
+                account2.getPublicAccount(),
+                hashLockTransaction,
+                transferTransaction1
+            ),
+            account3.getAddress(), alias2));
+
+        Assertions.assertTrue(transactionFromAddress(listener,
+            aggregateTransaction(account2.getPublicAccount(), null,
+                transferTransaction2,
+                hashLockTransaction,
+                transferTransaction1
+            ),
+            account2.getAddress()));
+
+        Assertions.assertTrue(transactionFromAddress(listener,
+            aggregateTransaction(account1.getPublicAccount(), account1.getPublicAccount(),
+                transferTransaction2,
+                hashLockTransaction,
+                transferTransaction1
+            ),
+            account2.getAddress()));
+
+        Assertions.assertTrue(transactionFromAddress(listener,
+            aggregateTransaction(null,
+                account2.getPublicAccount(),
+                hashLockTransaction,
+                transferTransaction1,
+                transferTransaction1,
+                transferTransaction1,
+                transferTransaction2,
+                transferTransaction1
+            ),
+            account3.getAddress(), alias2));
     }
 
     private AggregateTransaction aggregateTransaction(PublicAccount signer,
-        Transaction anotherTransaction, PublicAccount consignauturePublicAccount) {
+        PublicAccount consignauturePublicAccount, Transaction... anotherTransactions) {
         List<AggregateTransactionCosignature> cosignatures = new ArrayList<>();
         cosignatures
             .add(new AggregateTransactionCosignature("Signature", consignauturePublicAccount));
         AggregateTransactionFactory factory = AggregateTransactionFactory.create(
-            TransactionType.AGGREGATE_COMPLETE, NetworkType.MIJIN_TEST,
-            Collections.singletonList(anotherTransaction),
+            TransactionType.AGGREGATE_COMPLETE, NETWORK_TYPE,
+            Arrays.asList(anotherTransactions),
             cosignatures);
         if (signer != null) {
             factory.signer(signer);
@@ -707,14 +997,13 @@ public class ListenerVertxTest {
 
     private HashLockTransaction hashLockTransaction(PublicAccount signer) {
         SignedTransaction signedTransaction =
-            new SignedTransaction(
-                signer == null ? null : signer, "payload",
+            new SignedTransaction(signer, "payload",
                 "8498B38D89C1DC8A448EA5824938FF828926CD9F7747B1844B59B4B6807E878B",
                 TransactionType.AGGREGATE_BONDED);
         MosaicId mosaicId = MapperUtils.toMosaicId("123");
         Mosaic mosaic = new Mosaic(mosaicId, BigInteger.TEN);
         HashLockTransactionFactory factory = HashLockTransactionFactory.create(
-            NetworkType.MIJIN_TEST, mosaic,
+            NETWORK_TYPE, mosaic,
             BigInteger.TEN, signedTransaction.getHash());
         if (signer != null) {
             factory.signer(signer);


### PR DESCRIPTION
In this PR I add the alias resolution when detecting if an incoming transaction is related to an address. The alias resolution is as lazy as possible, only calling rest when it's necessary and only for the transactions that may have aliases