### PR TITLE
Fixed harvesting delegation message payload

### DIFF
--- a/integration-tests/src/test/java/io/nem/symbol/sdk/infrastructure/TransferTransactionIntegrationTest.java
+++ b/integration-tests/src/test/java/io/nem/symbol/sdk/infrastructure/TransferTransactionIntegrationTest.java
@@ -24,6 +24,7 @@ import io.nem.symbol.sdk.model.message.EncryptedMessage;
 import io.nem.symbol.sdk.model.message.Message;
 import io.nem.symbol.sdk.model.message.MessageType;
 import io.nem.symbol.sdk.model.message.PersistentHarvestingDelegationMessage;
+import io.nem.symbol.sdk.model.message.PersistentHarvestingDelegationMessage.HarvestingKeys;
 import io.nem.symbol.sdk.model.message.PlainMessage;
 import io.nem.symbol.sdk.model.namespace.NamespaceId;
 import io.nem.symbol.sdk.model.network.NetworkType;
@@ -46,31 +47,18 @@ public class TransferTransactionIntegrationTest extends BaseIntegrationTest {
     @EnumSource(RepositoryType.class)
     void aggregateTransferTransaction(RepositoryType type) {
         UnresolvedAddress recipient = getRecipient();
-        String message =
-            "E2ETest:aggregateTransferTransaction:messagelooooooooooooooooooooooooooooooooooooooo"
-                +
-                "ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
-                +
-                "ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
-                +
-                "ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
-                +
-                "ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
-                +
-                "ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
-                +
-                "oooooooong";
-        TransferTransaction transferTransaction =
-            TransferTransactionFactory.create(
-                getNetworkType(), recipient,
-                Collections
-                    .singletonList(getNetworkCurrency().createAbsolute(BigInteger.valueOf(1))),
-                new PlainMessage(message)
-            ).maxFee(this.maxFee).build();
+        String message = "E2ETest:aggregateTransferTransaction:messagelooooooooooooooooooooooooooooooooooooooo"
+            + "ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            + "oooooooong";
+        TransferTransaction transferTransaction = TransferTransactionFactory.create(getNetworkType(), recipient,
+            Collections.singletonList(getNetworkCurrency().createAbsolute(BigInteger.valueOf(1))),
+            new PlainMessage(message)).maxFee(this.maxFee).build();
 
-        TransferTransaction processed = announceAggregateAndValidate(type, transferTransaction,
-            account
-        ).getKey();
+        TransferTransaction processed = announceAggregateAndValidate(type, transferTransaction, account).getKey();
         Assertions.assertEquals(message, processed.getMessage().getPayload());
     }
 
@@ -80,25 +68,19 @@ public class TransferTransactionIntegrationTest extends BaseIntegrationTest {
         String namespaceName = "testaccount2";
 
         NamespaceId recipient = setAddressAlias(type, getRecipient(), namespaceName);
-        Assertions.assertEquals("9988DD7D72227ECAE7000000000000000000000000000000",
-            recipient.encoded(getNetworkType()));
+        Assertions
+            .assertEquals("9988DD7D72227ECAE7000000000000000000000000000000", recipient.encoded(getNetworkType()));
         String message = "E2ETest:standaloneTransferTransaction:message 漢字";
 
         KeyPair senderKeyPair = KeyPair.random();
         KeyPair recipientKeyPair = KeyPair.random();
 
         Message encryptedMessage = EncryptedMessage
-            .create(message, senderKeyPair.getPrivateKey(), recipientKeyPair.getPublicKey()
-            );
+            .create(message, senderKeyPair.getPrivateKey(), recipientKeyPair.getPublicKey());
 
-        TransferTransaction transferTransaction =
-            TransferTransactionFactory.create(
-                getNetworkType(),
-                recipient,
-                Collections
-                    .singletonList(getNetworkCurrency().createAbsolute(BigInteger.valueOf(1))),
-                encryptedMessage
-            ).maxFee(this.maxFee).build();
+        TransferTransaction transferTransaction = TransferTransactionFactory.create(getNetworkType(), recipient,
+            Collections.singletonList(getNetworkCurrency().createAbsolute(BigInteger.valueOf(1))), encryptedMessage)
+            .maxFee(this.maxFee).build();
 
         TransferTransaction processed = announceAndValidate(type, account, transferTransaction);
 
@@ -112,8 +94,7 @@ public class TransferTransactionIntegrationTest extends BaseIntegrationTest {
 
         assertTransferTransactions(transferTransaction, restTransaction);
 
-        assertEncryptedMessageTransaction(message, senderKeyPair, recipientKeyPair,
-            restTransaction);
+        assertEncryptedMessageTransaction(message, senderKeyPair, recipientKeyPair, restTransaction);
     }
 
 
@@ -127,45 +108,32 @@ public class TransferTransactionIntegrationTest extends BaseIntegrationTest {
 
         Account account = Account.generateNewAccount(networkType);
 
-        TransferTransaction transferTransaction =
-            TransferTransactionFactory.create(
-                getNetworkType(),
-                recipient,
-                Collections
-                    .singletonList(
-                        getNetworkCurrency().createAbsolute(BigInteger.valueOf(1000000000))),
-                PlainMessage.Empty
-            ).maxFee(this.maxFee).build();
+        TransferTransaction transferTransaction = TransferTransactionFactory.create(getNetworkType(), recipient,
+            Collections.singletonList(getNetworkCurrency().createAbsolute(BigInteger.valueOf(1000000000))),
+            PlainMessage.Empty).maxFee(this.maxFee).build();
 
-        IllegalArgumentException exceptions = Assertions
-            .assertThrows(IllegalArgumentException.class,
-                () -> announceAndValidate(type, account, transferTransaction));
+        IllegalArgumentException exceptions = Assertions.assertThrows(IllegalArgumentException.class,
+            () -> announceAndValidate(type, account, transferTransaction));
 
-        Assertions
-            .assertTrue(exceptions.getMessage().contains("Failure_Core_Insufficient_Balance"));
+        Assertions.assertTrue(exceptions.getMessage().contains("Failure_Core_Insufficient_Balance"));
 
 
     }
 
-    private void assertTransferTransactions(TransferTransaction expected,
-        TransferTransaction processed) {
-        Assertions
-            .assertEquals(expected.getRecipient().encoded(getNetworkType()),
-                processed.getRecipient().encoded(
-                    getNetworkType()));
+    private void assertTransferTransactions(TransferTransaction expected, TransferTransaction processed) {
+        Assertions.assertEquals(expected.getRecipient().encoded(getNetworkType()),
+            processed.getRecipient().encoded(getNetworkType()));
         Assertions.assertEquals(expected.getRecipient(), processed.getRecipient());
         Assertions.assertEquals(expected.getMessage().getType(), processed.getMessage().getType());
-        Assertions
-            .assertEquals(expected.getMessage().getPayload(), processed.getMessage().getPayload());
+        Assertions.assertEquals(expected.getMessage().getPayload(), processed.getMessage().getPayload());
     }
 
-    private void assertEncryptedMessageTransaction(String message,
-        KeyPair senderKeyPair, KeyPair recipientKeyPair, TransferTransaction transaction) {
+    private void assertEncryptedMessageTransaction(String message, KeyPair senderKeyPair, KeyPair recipientKeyPair,
+        TransferTransaction transaction) {
         Assertions.assertTrue(transaction.getMessage() instanceof EncryptedMessage);
         Assertions.assertNotEquals(message, transaction.getMessage().getPayload());
         String decryptedMessage = ((EncryptedMessage) transaction.getMessage())
-            .decryptPayload(senderKeyPair.getPublicKey(), recipientKeyPair.getPrivateKey()
-            );
+            .decryptPayload(senderKeyPair.getPublicKey(), recipientKeyPair.getPrivateKey());
         Assertions.assertNotNull(message, decryptedMessage);
     }
 
@@ -174,39 +142,36 @@ public class TransferTransactionIntegrationTest extends BaseIntegrationTest {
     @EnumSource(RepositoryType.class)
     public void standaloneCreatePersistentDelegationRequestTransaction(RepositoryType type) {
 
-        NetworkType networkType = getNetworkType();
         KeyPair senderKeyPair = KeyPair.random();
+        KeyPair vrfPrivateKey = KeyPair.random();
         KeyPair recipientKeyPair = KeyPair.random();
 
-        TransferTransaction transferTransaction =
-            TransferTransactionFactory.createPersistentDelegationRequestTransaction(
-                getNetworkType(), senderKeyPair.getPrivateKey(),
-                recipientKeyPair.getPublicKey()
-            ).maxFee(this.maxFee).build();
+        TransferTransaction transferTransaction = TransferTransactionFactory
+            .createPersistentDelegationRequestTransaction(getNetworkType(), senderKeyPair.getPrivateKey(),
+                vrfPrivateKey.getPrivateKey(), recipientKeyPair.getPublicKey()).maxFee(this.maxFee).build();
 
         TransferTransaction processed = announceAndValidate(type, account, transferTransaction);
 
-        assertPersistentDelegationTransaction(recipientKeyPair, processed);
+        assertPersistentDelegationTransaction(recipientKeyPair, vrfPrivateKey, processed);
 
         TransferTransaction restTransaction = (TransferTransaction) get(
             getRepositoryFactory(type).createTransactionRepository()
                 .getTransaction(TransactionGroup.CONFIRMED, processed.getTransactionInfo().get().getHash().get()));
 
-        assertPersistentDelegationTransaction(recipientKeyPair, restTransaction);
+        assertPersistentDelegationTransaction(recipientKeyPair, vrfPrivateKey, restTransaction);
     }
 
-    private void assertPersistentDelegationTransaction(
-        KeyPair recipientKeyPair, TransferTransaction transaction) {
+    private void assertPersistentDelegationTransaction(KeyPair recipientKeyPair, KeyPair vrfPrivateKey,
+        TransferTransaction transaction) {
         String message = recipientKeyPair.getPublicKey().toHex();
-        Assertions
-            .assertTrue(transaction.getMessage() instanceof PersistentHarvestingDelegationMessage);
+        Assertions.assertTrue(transaction.getMessage() instanceof PersistentHarvestingDelegationMessage);
         Assertions.assertNotEquals(message, transaction.getMessage().getPayload());
-        Assertions.assertEquals(MessageType.PERSISTENT_HARVESTING_DELEGATION_MESSAGE,
-            transaction.getMessage().getType());
-        String decryptedMessage = ((PersistentHarvestingDelegationMessage) transaction.getMessage())
-            .decryptPayload(recipientKeyPair.getPrivateKey()
-            );
-        Assertions.assertNotNull(message, decryptedMessage);
+        Assertions
+            .assertEquals(MessageType.PERSISTENT_HARVESTING_DELEGATION_MESSAGE, transaction.getMessage().getType());
+        HarvestingKeys decryptedMessage = ((PersistentHarvestingDelegationMessage) transaction.getMessage())
+            .decryptPayload(recipientKeyPair.getPrivateKey());
+        Assertions.assertEquals(recipientKeyPair.getPrivateKey(), decryptedMessage.getSigningPrivateKey());
+        Assertions.assertEquals(vrfPrivateKey.getPrivateKey(), decryptedMessage.getVrfPrivateKey());
     }
 
 }

--- a/sdk-core/src/main/java/io/nem/symbol/sdk/model/message/MessageMarker.java
+++ b/sdk-core/src/main/java/io/nem/symbol/sdk/model/message/MessageMarker.java
@@ -28,7 +28,7 @@ public class MessageMarker {
 
     }
     /**
-     * 8-byte marker: FE 2A 80 61 57 73 01 E2 for PersistentDelegationRequestTransaction message
+     * 8-byte marker: E201735761802AFE for PersistentDelegationRequestTransaction message
      */
-    public static final String PERSISTENT_DELEGATION_UNLOCK = "FE2A8061577301E2";
+    public static final String PERSISTENT_DELEGATION_UNLOCK = "E201735761802AFE";
 }

--- a/sdk-core/src/main/java/io/nem/symbol/sdk/model/message/PersistentHarvestingDelegationMessage.java
+++ b/sdk-core/src/main/java/io/nem/symbol/sdk/model/message/PersistentHarvestingDelegationMessage.java
@@ -24,73 +24,96 @@ import io.nem.symbol.core.crypto.PrivateKey;
 import io.nem.symbol.core.crypto.PublicKey;
 import io.nem.symbol.core.utils.ConvertUtils;
 import io.nem.symbol.core.utils.StringEncoder;
+import org.apache.commons.lang3.Validate;
 
 public class PersistentHarvestingDelegationMessage extends Message {
+
+    /**
+     * When decrypting, the message is converted back to the 2 original private keys.
+     */
+    public static class HarvestingKeys {
+
+        private final PrivateKey signingPrivateKey;
+        private final PrivateKey vrfPrivateKey;
+
+        private HarvestingKeys(PrivateKey signingPrivateKey, PrivateKey vrfPrivateKey) {
+            Validate.notNull(signingPrivateKey, "signingPrivateKey is required");
+            Validate.notNull(vrfPrivateKey, "vrfPrivateKey is required");
+            this.signingPrivateKey = signingPrivateKey;
+            this.vrfPrivateKey = vrfPrivateKey;
+        }
+
+        public PrivateKey getSigningPrivateKey() {
+            return signingPrivateKey;
+        }
+
+        public PrivateKey getVrfPrivateKey() {
+            return vrfPrivateKey;
+        }
+    }
 
     public PersistentHarvestingDelegationMessage(String payload) {
         super(MessageType.PERSISTENT_HARVESTING_DELEGATION_MESSAGE, payload);
     }
 
     /**
-     * Helper constructor that allow users to create an encrypted Persistent Harvesting Delegation
-     * Message
+     * Helper constructor that allow users to create an encrypted Persistent Harvesting Delegation Message
      *
-     * Note, the strategy to encrypt and decrypt should be shared between the different SDKs. A
-     * client may send a transaction using a sdk and the recipient may be using a different one.
+     * Note, the strategy to encrypt and decrypt should be shared between the different SDKs. A client may send a
+     * transaction using a sdk and the recipient may be using a different one.
      *
      * The strategy is:
      *
-     * "plain text" string - utf8 byte array - encrypted byte array - hex string (the encrypted
-     * message string)
+     * "plain text" string - utf8 byte array - encrypted byte array - hex string (the encrypted message string)
      *
-     * @param delegatedPrivateKey the remote’s account proxy private key.
-     * @param recipientPublicKey Recipient public key
+     * @param signingPrivateKey Remote harvester signing private key linked to the main account
+     * @param vrfPrivateKey VRF private key linked to the main account
+     * @param nodePublicKey Recipient public key
      * @return {@link PersistentHarvestingDelegationMessage}
      */
-    public static PersistentHarvestingDelegationMessage create(PrivateKey delegatedPrivateKey,
-        PublicKey recipientPublicKey) {
+    public static PersistentHarvestingDelegationMessage create(PrivateKey signingPrivateKey, PrivateKey vrfPrivateKey,
+        PublicKey nodePublicKey) {
 
-        KeyPair ephemeralKeypair = KeyPair.random();
+        KeyPair ephemeralKeyPair = KeyPair.random();
 
         CryptoEngine engine = CryptoEngines.defaultEngine();
 
-        KeyPair recipient = KeyPair.onlyPublic(recipientPublicKey, engine);
-        BlockCipher blockCipher = engine.createBlockCipher(ephemeralKeypair, recipient);
+        KeyPair recipient = KeyPair.onlyPublic(nodePublicKey, engine);
+        BlockCipher blockCipher = engine.createBlockCipher(ephemeralKeyPair, recipient);
 
         String payload =
-            MessageMarker.PERSISTENT_DELEGATION_UNLOCK + ephemeralKeypair.getPublicKey().toHex()
-                + ConvertUtils
-                .toHex(blockCipher.encrypt(StringEncoder.getBytes(delegatedPrivateKey.toHex())));
+            MessageMarker.PERSISTENT_DELEGATION_UNLOCK + ephemeralKeyPair.getPublicKey().toHex() + ConvertUtils
+                .toHex(blockCipher.encrypt(StringEncoder.getBytes(signingPrivateKey.toHex() + vrfPrivateKey.toHex())));
 
         return new PersistentHarvestingDelegationMessage(payload.toUpperCase());
     }
 
 
     /**
-     * Utility method that allow users to decrypt a message if it was created using the Java SDK or
-     * the Typescript SDK.
+     * Utility method that allow users to decrypt a message if it was created using the Java SDK or the Typescript SDK.
      *
      * @param recipientPrivateKey Recipient private key
-     * @return the recipient public key.
+     * @return the 2 private keys
      */
-    public String decryptPayload(PrivateKey recipientPrivateKey) {
+    public HarvestingKeys decryptPayload(PrivateKey recipientPrivateKey) {
 
         int markerLength = MessageMarker.PERSISTENT_DELEGATION_UNLOCK.length();
+        int publicKeyHexSize = PublicKey.SIZE * 2;
         PublicKey senderPublicKey = PublicKey
-            .fromHexString(getPayload().substring(markerLength, markerLength + 64));
+            .fromHexString(getPayload().substring(markerLength, markerLength + publicKeyHexSize));
 
-        String encryptedPayload = getPayload()
-            .substring(markerLength + senderPublicKey.toHex().length());
+        String encryptedPayload = getPayload().substring(markerLength + publicKeyHexSize);
 
         CryptoEngine engine = CryptoEngines.defaultEngine();
         KeyPair sender = KeyPair.onlyPublic(senderPublicKey, engine);
         KeyPair recipient = KeyPair.fromPrivate(recipientPrivateKey);
-        BlockCipher blockCipher = engine
-            .createBlockCipher(sender, recipient);
+        BlockCipher blockCipher = engine.createBlockCipher(sender, recipient);
 
-        return StringEncoder
-            .getString(blockCipher.decrypt(ConvertUtils.fromHexToBytes(encryptedPayload)))
+        String doubleKey = StringEncoder.getString(blockCipher.decrypt(ConvertUtils.fromHexToBytes(encryptedPayload)))
             .toUpperCase();
+        PrivateKey signingPrivateKey = PrivateKey.fromHexString(doubleKey.substring(0, publicKeyHexSize));
+        PrivateKey vrfPrivateKey = PrivateKey.fromHexString(doubleKey.substring(publicKeyHexSize));
+        return new HarvestingKeys(signingPrivateKey, vrfPrivateKey);
     }
 
 }

--- a/sdk-core/src/main/java/io/nem/symbol/sdk/model/transaction/TransferTransactionFactory.java
+++ b/sdk-core/src/main/java/io/nem/symbol/sdk/model/transaction/TransferTransactionFactory.java
@@ -37,11 +37,8 @@ public class TransferTransactionFactory extends TransactionFactory<TransferTrans
     private final List<Mosaic> mosaics;
     private final Message message;
 
-    private TransferTransactionFactory(
-        final NetworkType networkType,
-        final UnresolvedAddress recipient,
-        final List<Mosaic> mosaics,
-        final Message message) {
+    private TransferTransactionFactory(final NetworkType networkType, final UnresolvedAddress recipient,
+        final List<Mosaic> mosaics, final Message message) {
         super(TransactionType.TRANSFER, networkType);
         Validate.notNull(recipient, "Recipient must not be null");
         Validate.notNull(mosaics, "Mosaics must not be null");
@@ -60,32 +57,26 @@ public class TransferTransactionFactory extends TransactionFactory<TransferTrans
      * @param message Message.
      * @return Transfer transaction.
      */
-    public static TransferTransactionFactory create(
-        final NetworkType networkType,
-        final UnresolvedAddress recipient,
-        final List<Mosaic> mosaics,
-        final Message message) {
+    public static TransferTransactionFactory create(final NetworkType networkType, final UnresolvedAddress recipient,
+        final List<Mosaic> mosaics, final Message message) {
         return new TransferTransactionFactory(networkType, recipient, mosaics, message);
     }
 
     /**
-     * Creates a TransferTransactionFactory with special message payload for persistent harvesting
-     * delegation unlocking
+     * Creates a TransferTransactionFactory with special message payload for persistent harvesting delegation unlocking
      *
      * @param networkType The network type.
-     * @param remoteProxyPrivateKey the remote’s account proxy private key.=
-     * @param harvesterPublicKey The harvester public key
+     * @param signingPrivateKey Remote harvester signing private key linked to the main account
+     * @param vrfPrivateKey VRF private key linked to the main account
+     * @param nodePublicKey Recipient public key
      * @return {@link TransferTransactionFactory}
      */
-    public static TransferTransactionFactory createPersistentDelegationRequestTransaction(
-        NetworkType networkType,
-        PrivateKey remoteProxyPrivateKey,
-        PublicKey harvesterPublicKey) {
+    public static TransferTransactionFactory createPersistentDelegationRequestTransaction(NetworkType networkType,
+        PrivateKey signingPrivateKey, PrivateKey vrfPrivateKey, PublicKey nodePublicKey) {
         PersistentHarvestingDelegationMessage message = PersistentHarvestingDelegationMessage
-            .create(remoteProxyPrivateKey, harvesterPublicKey);
+            .create(signingPrivateKey, vrfPrivateKey, nodePublicKey);
         return new TransferTransactionFactory(networkType,
-            Address.createFromPublicKey(harvesterPublicKey.toHex(), networkType),
-            Collections.emptyList(), message);
+            Address.createFromPublicKey(nodePublicKey.toHex(), networkType), Collections.emptyList(), message);
     }
 
     /**

--- a/sdk-core/src/test/java/io/nem/symbol/sdk/model/message/PersistentHarvestingDelegationMessageTest.java
+++ b/sdk-core/src/test/java/io/nem/symbol/sdk/model/message/PersistentHarvestingDelegationMessageTest.java
@@ -17,6 +17,7 @@
 package io.nem.symbol.sdk.model.message;
 
 import io.nem.symbol.core.crypto.KeyPair;
+import io.nem.symbol.sdk.model.message.PersistentHarvestingDelegationMessage.HarvestingKeys;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -27,19 +28,21 @@ public class PersistentHarvestingDelegationMessageTest {
 
     @Test
     public void testCreateEncryptedMessage() {
-        KeyPair proxy = KeyPair.random();
+        KeyPair signing = KeyPair.random();
+        KeyPair vrf = KeyPair.random();
         KeyPair harvester = KeyPair.random();
 
         PersistentHarvestingDelegationMessage encryptedMessage = PersistentHarvestingDelegationMessage
-            .create(proxy.getPrivateKey(), harvester.getPublicKey());
+            .create(signing.getPrivateKey(), vrf.getPrivateKey(), harvester.getPublicKey());
 
-        Assertions.assertEquals(MessageType.PERSISTENT_HARVESTING_DELEGATION_MESSAGE,
-            encryptedMessage.getType());
+        Assertions.assertTrue(encryptedMessage.getPayload().startsWith(MessageMarker.PERSISTENT_DELEGATION_UNLOCK));
 
-        String plainMessage = encryptedMessage
-            .decryptPayload(harvester.getPrivateKey());
+        Assertions.assertEquals(MessageType.PERSISTENT_HARVESTING_DELEGATION_MESSAGE, encryptedMessage.getType());
 
-        Assertions.assertEquals(proxy.getPrivateKey().toHex().toUpperCase(), plainMessage);
+        HarvestingKeys plainMessage = encryptedMessage.decryptPayload(harvester.getPrivateKey());
+
+        Assertions.assertEquals(signing.getPrivateKey(), plainMessage.getSigningPrivateKey());
+        Assertions.assertEquals(vrf.getPrivateKey(), plainMessage.getVrfPrivateKey());
     }
 
 


### PR DESCRIPTION
- Updated delegated harvesting message marker to `E201735761802AFE`
- Added vrf private key to the message payload, so the encrypted message payload becomes `signingPrivateKey + vrfPrivateKey`

Fixes https://github.com/nemtech/symbol-sdk-java/issues/332