### PR TITLE
Updated version to release server 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,16 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [0.21.0] - 21-Sep-2020
+## [0.21.0] - 25-Sep-2020
 
-**Milestone**: Gorilla.1(0.10.0.1.0)
+**Milestone**: Catapult-server finality(0.10.0.3)
  Package  | Version  | Link
 ---|---|---
 SDK OkHttp| v0.21.0 | https://repo.maven.apache.org/maven2/io/nem/symbol-sdk-okhttp-client
 SDK Vertx| v0.21.0 | https://repo.maven.apache.org/maven2/io/nem/symbol-sdk-vertx-client
 Catbuffer Library| v0.0.23 | https://repo.maven.apache.org/maven2/io/nem/catbuffer-java
-Client OkHttp | v0.10.0.1  | https://repo.maven.apache.org/maven2/io/nem/symbol-openapi-okhttp-gson-client
-Client Vertx | v0.10.0.1  | https://repo.maven.apache.org/maven2/io/nem/symbol-openapi-vertx-client/
+Client OkHttp | v0.10.0  | https://repo.maven.apache.org/maven2/io/nem/symbol-openapi-okhttp-gson-client
+Client Vertx | v0.10.0  | https://repo.maven.apache.org/maven2/io/nem/symbol-openapi-vertx-client/
 
 - **[BREAKING CHANGE]** Updated `ChainRepository` merging Height and Score into Info object. Added finalized block information.
 - **[BREAKING CHANGE]** Updated `RestrictionMosaicRepository` adding pagination.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Each SDK user can depend on the best library for its need (example, ``symbol-sdk
 <dependency>
     <groupId>io.nem</groupId>
     <artifactId>symbol-sdk-vertx-client</artifactId>
-    <version>0.20.3</version>
+    <version>0.21.0</version>
 </dependency>
 ```
 
@@ -33,25 +33,25 @@ OR
 <dependency>
     <groupId>io.nem</groupId>
     <artifactId>symbol-sdk-okhttp-client</artifactId>
-    <version>0.20.3</version>
+    <version>0.21.0</version>
 </dependency>
 ```
 
 ### Gradle
 
-```compile 'io.nem:symbol-sdk-vertx-client:0.20.3```
+```compile 'io.nem:symbol-sdk-vertx-client:0.21.0```
 
 OR
 
-```compile 'io.nem:symbol-sdk-okhttp-client:0.20.3```
+```compile 'io.nem:symbol-sdk-okhttp-client:0.21.0```
 
 ### SBT
 
-```libraryDependencies += "io.nem" % "symbol-sdk-vertx-client" % "0.20.3"```
+```libraryDependencies += "io.nem" % "symbol-sdk-vertx-client" % "0.21.0"```
 
 OR
 
-```libraryDependencies += "io.nem" % "symbol-sdk-okhttp-client" % "0.20.3"```
+```libraryDependencies += "io.nem" % "symbol-sdk-okhttp-client" % "0.21.0"```
 
 ## Usage
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ ext {
     rxjavaVersion = "2.1.7"
     junitVersion = "5.4.0"
     catbufferVersion = "0.0.23"
-    restApiVersion = "0.10.0-SNAPSHOT"
+    restApiVersion = "0.10.0"
     jackson_version = "2.9.9"
     jackson_databind_version = "2.9.9"
 }


### PR DESCRIPTION
## [0.21.0] - 25-Sep-2020

**Milestone**: Catapult-server finality(0.10.0.3)
 Package  | Version  | Link
---|---|---
SDK OkHttp| v0.21.0 | https://repo.maven.apache.org/maven2/io/nem/symbol-sdk-okhttp-client
SDK Vertx| v0.21.0 | https://repo.maven.apache.org/maven2/io/nem/symbol-sdk-vertx-client
Catbuffer Library| v0.0.23 | https://repo.maven.apache.org/maven2/io/nem/catbuffer-java
Client OkHttp | v0.10.0  | https://repo.maven.apache.org/maven2/io/nem/symbol-openapi-okhttp-gson-client
Client Vertx | v0.10.0  | https://repo.maven.apache.org/maven2/io/nem/symbol-openapi-vertx-client/

- **[BREAKING CHANGE]** Updated `ChainRepository` merging Height and Score into Info object. Added finalized block information.
- **[BREAKING CHANGE]** Updated `RestrictionMosaicRepository` adding pagination.
- **[BREAKING CHANGE]** Updated `RestrictionAccountRepository` getter.
- **[BREAKING CHANGE]** Simplified `MosaicNonce`. It works with an `int` instead of a `byte[]`.
- **[BREAKING CHANGE]** Messages in Transfer Transactions are optional. `TransferTransactionFactory` creates a transaction with no message by default. `PlainMessage.Empty` has been removed.
- **[BREAKING CHANGE]** Renamed `numTransactions` and `numStatements` in `BlockInfo` to `transactionsCount` and `statementsCount`.
- Added support for topic/data payload wrapper in WS Listener allowing users to reuse the connection for different channels.
- Added `finalizedBlock` WS Listener subscription
- Added `SecretLockRepository` and `HashLockRepository`
- Improved API around cosignatures and cosigners and how they can be added to aggregate transactions. 
- Added [symbol-bootstrap](https://github.com/nemtech/symbol-bootstrap) integration.
- Added From and To Height filters to `TransactionRepository` searches.
- Restyled code using [spotless](https://github.com/diffplug/spotless/tree/main/plugin-gradle).